### PR TITLE
CSP-613 Fixes providers integration endpoint to return all provider types

### DIFF
--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
@@ -1,15 +1,14 @@
-﻿using MediatR;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.ProviderCourse.Queries.GetAllProviderCourses;
+using SFA.DAS.Roatp.Application.ProviderCourse.Queries.GetProviderCourse;
 using SFA.DAS.Roatp.Application.Providers.Queries.GetProviders;
 using SFA.DAS.Roatp.Application.Providers.Queries.GetProviderSummary;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using SFA.DAS.Roatp.Application.ProviderCourse.Queries.GetProviderCourse;
-using Azure;
-using SFA.DAS.Roatp.Api.Infrastructure;
 
 namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
 {

--- a/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetProvider/GetProviderQueryResultTests.cs
+++ b/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetProvider/GetProviderQueryResultTests.cs
@@ -22,6 +22,7 @@ namespace SFA.DAS.Roatp.Application.UnitTests.Providers.Queries.GetProvider
                 .Excluding(s => s.LearnerSatisfaction)
                 .Excluding(s => s.NationalAchievementRates)
                 .Excluding(s => s.ProviderAddress)
+                .Excluding(s => s.ProviderRegistrationDetail)
             );
         }
     }

--- a/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetProviders/ProviderAddressModelTests.cs
+++ b/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetProviders/ProviderAddressModelTests.cs
@@ -24,8 +24,6 @@ namespace SFA.DAS.Roatp.Application.UnitTests.Providers.Queries.GetProviders
             model.Postcode.Should().Be(source.Postcode);
             model.Latitude.Should().Be(source.Latitude);
             model.Longitude.Should().Be(source.Longitude);
-            model.AddressUpdateDate.Should().Be(source.AddressUpdateDate);
-            model.CoordinatesUpdateDate.Should().Be(source.CoordinatesUpdateDate);
         }
     }
 }

--- a/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetProviders/ProviderAddressModelTests.cs
+++ b/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetProviders/ProviderAddressModelTests.cs
@@ -14,8 +14,6 @@ namespace SFA.DAS.Roatp.Application.UnitTests.Providers.Queries.GetProviders
         {
             var model = (ProviderAddressModel)source;
 
-            model.Id.Should().Be(source.Id);
-            model.ProviderId.Should().Be(source.ProviderId);
             model.AddressLine1.Should().Be(source.AddressLine1);
             model.AddressLine2.Should().Be(source.AddressLine2);
             model.AddressLine3.Should().Be(source.AddressLine3);

--- a/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetProviders/ProviderSummaryTests.cs
+++ b/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetProviders/ProviderSummaryTests.cs
@@ -10,16 +10,16 @@ namespace SFA.DAS.Roatp.Application.UnitTests.Providers.Queries.GetProviders
     public class ProviderSummaryTests
     {
         [Test, RecursiveMoqAutoData]
-        public void Operator_PopulatesModelFromEntity(Provider source)
+        public void Operator_PopulatesModelFromEntity(ProviderRegistrationDetail source)
         {
             var model = (ProviderSummary)source;
 
             model.Ukprn.Should().Be(source.Ukprn);
             model.Name.Should().Be(source.LegalName);
-            model.TradingName.Should().Be(source.TradingName);
-            model.Email.Should().Be(source.Email);
-            model.Phone.Should().Be(source.Phone);
-            model.ContactUrl.Should().Be(source.Website);
+            model.TradingName.Should().Be(source.Provider.TradingName);
+            model.Email.Should().Be(source.Provider.Email);
+            model.Phone.Should().Be(source.Provider.Phone);
+            model.ContactUrl.Should().Be(source.Provider.Website);
         }
     }
 }

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviderSummary/GetProviderSummaryQueryHandler.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviderSummary/GetProviderSummaryQueryHandler.cs
@@ -1,31 +1,30 @@
-﻿using MediatR;
-using Microsoft.Extensions.Logging;
-using SFA.DAS.Roatp.Application.Providers.Queries.GetProviders;
-using SFA.DAS.Roatp.Domain.Interfaces;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Application.Mediatr.Responses;
+using SFA.DAS.Roatp.Domain.Interfaces;
 
 namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviderSummary
 {
     public class GetProviderSummaryQueryHandler : IRequestHandler<GetProviderSummaryQuery, ValidatedResponse<GetProviderSummaryQueryResult>>
     {
-        private readonly IProvidersReadRepository _providersReadRepository;
+        private readonly IProviderRegistrationDetailsReadRepository _providersRegistrationDetailReadRepository;
         private readonly ILogger<GetProviderSummaryQueryHandler> _logger;
 
-        public GetProviderSummaryQueryHandler(IProvidersReadRepository providersReadRepository,  ILogger<GetProviderSummaryQueryHandler> logger)
+        public GetProviderSummaryQueryHandler(IProviderRegistrationDetailsReadRepository providersRegistrationDetailReadRepository, ILogger<GetProviderSummaryQueryHandler> logger)
         {
-            _providersReadRepository = providersReadRepository;
+            _providersRegistrationDetailReadRepository = providersRegistrationDetailReadRepository;
             _logger = logger;
         }
-        
+
         public async Task<ValidatedResponse<GetProviderSummaryQueryResult>> Handle(GetProviderSummaryQuery request, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Getting provider summary for ukprn [{ukprn}]", request.Ukprn);
-            var provider = await _providersReadRepository.GetByUkprn(request.Ukprn);
+            var provider = await _providersRegistrationDetailReadRepository.GetProviderRegistrationDetail(request.Ukprn);
             return new ValidatedResponse<GetProviderSummaryQueryResult>(new GetProviderSummaryQueryResult
             {
-                ProviderSummary = (ProviderSummary)provider
+                ProviderSummary = provider
             });
         }
     }

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviderSummary/GetProviderSummaryQueryValidator.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviderSummary/GetProviderSummaryQueryValidator.cs
@@ -1,14 +1,19 @@
 ﻿using FluentValidation;
-using SFA.DAS.Roatp.Application.Common;
 using SFA.DAS.Roatp.Domain.Interfaces;
 
 namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviderSummary
 {
     public class GetProviderSummaryQueryValidator : AbstractValidator<GetProviderSummaryQuery>
     {
+        public const string InvalidUkprnErrorMessage = "Invalid ukprn";
+        public const string ProviderNotFoundErrorMessage = "No provider found with given ukprn";
         public GetProviderSummaryQueryValidator(IProvidersReadRepository providersReadRepository)
         {
-            Include(new UkprnValidator(providersReadRepository));
+
+            RuleFor(x => x.Ukprn)
+                .Cascade(CascadeMode.Stop)
+                .GreaterThan(10000000).WithMessage(InvalidUkprnErrorMessage)
+                .LessThan(99999999).WithMessage(InvalidUkprnErrorMessage);
         }
     }
 }

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/GetProvidersQueryHandler.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/GetProvidersQueryHandler.cs
@@ -1,28 +1,28 @@
-﻿using MediatR;
-using Microsoft.Extensions.Logging;
-using SFA.DAS.Roatp.Domain.Interfaces;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.Roatp.Domain.Interfaces;
 
 namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviders
 {
     public class GetProvidersQueryHandler : IRequestHandler<GetProvidersQuery, GetProvidersQueryResult>
     {
-        private readonly IProvidersReadRepository _providersReadRepository;
+        private readonly IProviderRegistrationDetailsReadRepository _providersRegistrationDetailReadRepository;
         private readonly ILogger<GetProvidersQueryHandler> _logger;
 
-        public GetProvidersQueryHandler(IProvidersReadRepository providersReadRepository,  ILogger<GetProvidersQueryHandler> logger)
+        public GetProvidersQueryHandler(IProviderRegistrationDetailsReadRepository providersRegistrationDetailReadRepository, ILogger<GetProvidersQueryHandler> logger)
         {
-            _providersReadRepository = providersReadRepository;
+            _providersRegistrationDetailReadRepository = providersRegistrationDetailReadRepository;
             _logger = logger;
         }
-        
+
         public async Task<GetProvidersQueryResult> Handle(GetProvidersQuery request, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Getting providers summary");
-            var providers = await _providersReadRepository.GetAllProviders();
-            var providersSummary = providers.Select(p => (ProviderSummary)p).ToList();
+            var providers = await _providersRegistrationDetailReadRepository.GetActiveProviderRegistrations();
+            var providersSummary = providers.Select(p => (ProviderSummary)p);
             return new GetProvidersQueryResult
             {
                 RegisteredProviders = providersSummary

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/GetProvidersQueryResult.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/GetProvidersQueryResult.cs
@@ -4,6 +4,6 @@ namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviders
 {
     public class GetProvidersQueryResult
     {
-        public List<ProviderSummary> RegisteredProviders { get; set; } = new List<ProviderSummary>();
+        public IEnumerable<ProviderSummary> RegisteredProviders { get; set; } = new List<ProviderSummary>();
     }
 }

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/ProviderAddressModel.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/ProviderAddressModel.cs
@@ -1,5 +1,4 @@
 ﻿using SFA.DAS.Roatp.Domain.Entities;
-using System;
 
 namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviders
 {
@@ -15,12 +14,23 @@ namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviders
         public string Postcode { get; set; }
         public double? Latitude { get; set; }
         public double? Longitude { get; set; }
-        public DateTime? AddressUpdateDate { get; set; }
-        public DateTime? CoordinatesUpdateDate { get; set; }
+
+        public static implicit operator ProviderAddressModel(ProviderRegistrationDetail source) =>
+            new ProviderAddressModel
+            {
+                AddressLine1 = source.AddressLine1,
+                AddressLine2 = source.AddressLine2,
+                AddressLine3 = source.AddressLine3,
+                AddressLine4 = source.AddressLine4,
+                Town = source.Town,
+                Postcode = source.Postcode,
+                Latitude = source.Latitude,
+                Longitude = source.Longitude
+            };
 
         public static implicit operator ProviderAddressModel(ProviderAddress source)
         {
-            if(source == null)
+            if (source == null)
                 return null;
 
             return new ProviderAddressModel
@@ -34,9 +44,7 @@ namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviders
                 Town = source.Town,
                 Postcode = source.Postcode,
                 Latitude = source.Latitude,
-                Longitude = source.Longitude,
-                AddressUpdateDate = source.AddressUpdateDate,
-                CoordinatesUpdateDate = source.CoordinatesUpdateDate,
+                Longitude = source.Longitude
             };
         }
     }

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/ProviderAddressModel.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/ProviderAddressModel.cs
@@ -4,8 +4,6 @@ namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviders
 {
     public class ProviderAddressModel
     {
-        public int Id { get; set; }
-        public int ProviderId { get; set; }
         public string AddressLine1 { get; set; }
         public string AddressLine2 { get; set; }
         public string AddressLine3 { get; set; }
@@ -35,8 +33,6 @@ namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviders
 
             return new ProviderAddressModel
             {
-                Id = source.Id,
-                ProviderId = source.ProviderId,
                 AddressLine1 = source.AddressLine1,
                 AddressLine2 = source.AddressLine2,
                 AddressLine3 = source.AddressLine3,

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/ProviderSummary.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/ProviderSummary.cs
@@ -8,13 +8,24 @@ namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviders
         public string Name { get; set; }
         public string TradingName { get; set; }
         public string Email { get; set; }
-        public string Phone { get ; set ; }
-        public string ContactUrl { get ; set ; }
+        public string Phone { get; set; }
+        public string ContactUrl { get; set; }
         public ProviderAddressModel Address { get; set; } = new ProviderAddressModel();
 
-        public static implicit operator ProviderSummary(Provider source)
-        {
-            return new ProviderSummary
+        public static implicit operator ProviderSummary(ProviderRegistrationDetail source) =>
+            new ProviderSummary
+            {
+                Ukprn = source.Ukprn,
+                Name = source.LegalName,
+                TradingName = source.Provider?.TradingName,
+                Email = source.Provider?.Email,
+                Phone = source.Provider?.Phone,
+                ContactUrl = source.Provider?.Website,
+                Address = source
+            };
+
+        public static implicit operator ProviderSummary(Provider source) =>
+            new ProviderSummary
             {
                 Ukprn = source.Ukprn,
                 Name = source.LegalName,
@@ -22,8 +33,7 @@ namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviders
                 Email = source.Email,
                 Phone = source.Phone,
                 ContactUrl = source.Website,
-                Address = (ProviderAddressModel)source.ProviderAddress
+                Address = source.ProviderAddress
             };
-        }
     }
 }

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/ProviderSummary.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProviders/ProviderSummary.cs
@@ -13,7 +13,7 @@ namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviders
         public ProviderAddressModel Address { get; set; } = new ProviderAddressModel();
 
         public static implicit operator ProviderSummary(ProviderRegistrationDetail source) =>
-            new ProviderSummary
+            source == null ? null : new ProviderSummary
             {
                 Ukprn = source.Ukprn,
                 Name = source.LegalName,
@@ -22,18 +22,6 @@ namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProviders
                 Phone = source.Provider?.Phone,
                 ContactUrl = source.Provider?.Website,
                 Address = source
-            };
-
-        public static implicit operator ProviderSummary(Provider source) =>
-            new ProviderSummary
-            {
-                Ukprn = source.Ukprn,
-                Name = source.LegalName,
-                TradingName = source.TradingName,
-                Email = source.Email,
-                Phone = source.Phone,
-                ContactUrl = source.Website,
-                Address = source.ProviderAddress
             };
     }
 }

--- a/src/SFA.DAS.Roatp.Data/Configuration/ProviderRegistrationDetailConfiguration.cs
+++ b/src/SFA.DAS.Roatp.Data/Configuration/ProviderRegistrationDetailConfiguration.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SFA.DAS.Roatp.Domain.Entities;
-using System.Diagnostics.CodeAnalysis;
 
 namespace SFA.DAS.Roatp.Data.Configuration
 {
@@ -11,7 +11,8 @@ namespace SFA.DAS.Roatp.Data.Configuration
         public void Configure(EntityTypeBuilder<ProviderRegistrationDetail> builder)
         {
             builder.ToTable(nameof(ProviderRegistrationDetail));
-            builder.HasKey(p => p.Ukprn);
+            builder.HasKey(r => r.Ukprn);
+            builder.HasOne(r => r.Provider).WithOne(p => p.ProviderRegistrationDetail).HasForeignKey<Provider>(p => p.Ukprn);
         }
     }
 }

--- a/src/SFA.DAS.Roatp.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SFA.DAS.Roatp.Data/Extensions/ServiceCollectionExtensions.cs
@@ -50,6 +50,7 @@ namespace SFA.DAS.Roatp.Data.Extensions
             services.AddTransient<IProviderCourseLocationsBulkRepository, ProviderCourseLocationsBulkRepository>();
             services.AddTransient<ILoadProviderRepository, LoadProviderRepository>();
             services.AddTransient<IProviderRegistrationDetailsReadRepository, ProviderRegistrationDetailsReadRepository>();
+            services.AddTransient<IProviderRegistrationDetailsWriteRepository, ProviderRegistrationDetailsWriteRepository>();
             services.AddTransient<IProviderLocationsWriteRepository, ProviderLocationsWriteRepository>();
             services.AddTransient<IProviderCourseLocationsWriteRepository, ProviderCourseLocationsWriteRepository>();
             services.AddTransient<IImportAuditWriteRepository, ImportAuditWriteRepository>();
@@ -61,7 +62,7 @@ namespace SFA.DAS.Roatp.Data.Extensions
             services.AddTransient<INationalAchievementRatesOverallImportReadRepository, NationalAchievementRatesOverallImportReadRepository>();
             services.AddTransient<INationalAchievementRatesOverallWriteRepository, NationalAchievementRatesOverallWriteRepository>();
             services.AddTransient<INationalAchievementRatesOverallReadRepository, NationalAchievementRatesOverallReadRepository>();
-            services.AddTransient<IReloadProviderAddressesRepository,ReloadProviderAddressesRepository>();
+            services.AddTransient<IReloadProviderAddressesRepository, ReloadProviderAddressesRepository>();
             services.AddTransient<IProviderAddressReadRepository, ProviderAddressReadRepository>();
             services.AddTransient<IProviderAddressWriteRepository, ProviderAddressWriteRepository>();
             services.AddTransient<IProviderDetailsReadRepository, ProviderDetailsReadRepository>();

--- a/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsReadRepository.cs
+++ b/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsReadRepository.cs
@@ -11,7 +11,7 @@ using SFA.DAS.Roatp.Domain.Interfaces;
 namespace SFA.DAS.Roatp.Data.Repositories
 {
     [ExcludeFromCodeCoverage]
-    public class ProviderRegistrationDetailsReadRepository: IProviderRegistrationDetailsReadRepository
+    public class ProviderRegistrationDetailsReadRepository : IProviderRegistrationDetailsReadRepository
     {
         private readonly RoatpDataContext _roatpDataContext;
         private readonly ILogger<ProviderRegistrationDetailsReadRepository> _logger;
@@ -24,11 +24,15 @@ namespace SFA.DAS.Roatp.Data.Repositories
 
         public async Task<List<ProviderRegistrationDetail>> GetActiveProviderRegistrations()
         {
-            var activeProviders =  await _roatpDataContext.ProviderRegistrationDetails.Where(x =>
-                                                x.StatusId == OrganisationStatus.Active || 
-                                                x.StatusId == OrganisationStatus.ActiveNotTakingOnApprentices ||
-                                                x.StatusId == OrganisationStatus.Onboarding).AsNoTracking().ToListAsync();
-            
+            var activeProviders = await _roatpDataContext.ProviderRegistrationDetails
+                .Where(x =>
+                        x.StatusId == OrganisationStatus.Active ||
+                        x.StatusId == OrganisationStatus.ActiveNotTakingOnApprentices ||
+                        x.StatusId == OrganisationStatus.Onboarding)
+                .Include(r => r.Provider)
+                .AsNoTracking()
+                .ToListAsync();
+
             _logger.LogInformation("Retrieved {count} active provider registration details from ProviderRegistrationDetail", activeProviders.Count);
 
             return activeProviders.ToList();

--- a/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsReadRepository.cs
+++ b/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsReadRepository.cs
@@ -39,7 +39,14 @@ namespace SFA.DAS.Roatp.Data.Repositories
         }
 
         public async Task<ProviderRegistrationDetail> GetProviderRegistrationDetail(int ukprn) =>
-            await _roatpDataContext.ProviderRegistrationDetails.Include(r => r.Provider)
-                       .AsNoTracking().SingleOrDefaultAsync(p => p.Ukprn == ukprn);
+            await _roatpDataContext
+                    .ProviderRegistrationDetails
+                    .Where(x =>
+                        x.StatusId == OrganisationStatus.Active ||
+                        x.StatusId == OrganisationStatus.ActiveNotTakingOnApprentices ||
+                        x.StatusId == OrganisationStatus.Onboarding)
+                    .Include(r => r.Provider)
+                    .AsNoTracking()
+                    .SingleOrDefaultAsync(p => p.Ukprn == ukprn);
     }
 }

--- a/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsReadRepository.cs
+++ b/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsReadRepository.cs
@@ -38,10 +38,8 @@ namespace SFA.DAS.Roatp.Data.Repositories
             return activeProviders.ToList();
         }
 
-        public async Task<ProviderRegistrationDetail> GetProviderRegistrationDetail(int ukprn)
-        {
-            return await _roatpDataContext.ProviderRegistrationDetails
+        public async Task<ProviderRegistrationDetail> GetProviderRegistrationDetail(int ukprn) =>
+            await _roatpDataContext.ProviderRegistrationDetails.Include(r => r.Provider)
                        .AsNoTracking().SingleOrDefaultAsync(p => p.Ukprn == ukprn);
-        }
     }
 }

--- a/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsWriteRepository.cs
+++ b/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsWriteRepository.cs
@@ -28,11 +28,11 @@ namespace SFA.DAS.Roatp.Data.Repositories
                 x.StatusId == OrganisationStatus.Onboarding)
             .ToListAsync();
 
-        public async Task UpdateProviders(DateTime timeStarted, int providerCount)
+        public async Task UpdateProviders(DateTime timeStarted, int providerCount, ImportType importType)
         {
             // since the entities were retrieved with tracking on, it is assumed that when the call is made the tracked entities are already updated
             // hence just need to add the audit entity and commit the changes here
-            _roatpDataContext.ImportAudits.Add(new ImportAudit(timeStarted, providerCount, ImportType.ProviderRegistrationAddresses));
+            _roatpDataContext.ImportAudits.Add(new ImportAudit(timeStarted, providerCount, importType));
             await _roatpDataContext.SaveChangesAsync();
         }
     }

--- a/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsWriteRepository.cs
+++ b/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsWriteRepository.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using SFA.DAS.Roatp.Data.Constants;
+using SFA.DAS.Roatp.Domain.Entities;
+using SFA.DAS.Roatp.Domain.Interfaces;
+
+namespace SFA.DAS.Roatp.Data.Repositories
+{
+    [ExcludeFromCodeCoverage]
+    public class ProviderRegistrationDetailsWriteRepository : IProviderRegistrationDetailsWriteRepository
+    {
+        private readonly RoatpDataContext _roatpDataContext;
+
+        public ProviderRegistrationDetailsWriteRepository(RoatpDataContext roatpDataContext)
+        {
+            _roatpDataContext = roatpDataContext;
+        }
+
+        public async Task<List<ProviderRegistrationDetail>> GetActiveProviders() =>
+            await _roatpDataContext.ProviderRegistrationDetails
+            .Where(x =>
+                x.StatusId == OrganisationStatus.Active ||
+                x.StatusId == OrganisationStatus.ActiveNotTakingOnApprentices ||
+                x.StatusId == OrganisationStatus.Onboarding)
+            .ToListAsync();
+
+        public async Task UpdateProviders(DateTime timeStarted, int providerCount)
+        {
+            // since the entities were retrieved with tracking on, it is assumed that when the call is made the tracked entities are already updated
+            // hence just need to add the audit entity and commit the changes here
+            _roatpDataContext.ImportAudits.Add(new ImportAudit(timeStarted, providerCount, ImportType.ProviderRegistrationAddresses));
+            await _roatpDataContext.SaveChangesAsync();
+        }
+    }
+}

--- a/src/SFA.DAS.Roatp.Data/Repositories/ReloadProviderRegistrationDetailsRepository.cs
+++ b/src/SFA.DAS.Roatp.Data/Repositories/ReloadProviderRegistrationDetailsRepository.cs
@@ -1,12 +1,12 @@
-﻿using EFCore.BulkExtensions;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using EFCore.BulkExtensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Domain.Entities;
 using SFA.DAS.Roatp.Domain.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.Roatp.Data.Repositories
 {
@@ -22,13 +22,14 @@ namespace SFA.DAS.Roatp.Data.Repositories
             _logger = logger;
         }
 
-        public async Task<bool> ReloadRegisteredProviders(List<ProviderRegistrationDetail> providerRegistrationDetails)
+        public async Task<bool> ReloadRegisteredProviders(List<ProviderRegistrationDetail> providerRegistrationDetails, DateTime timeStarted)
         {
             await using var transaction = await _roatpDataContext.Database.BeginTransactionAsync();
             try
             {
                 await _roatpDataContext.Database.ExecuteSqlInterpolatedAsync($"DELETE FROM ProviderRegistrationDetail");
                 await _roatpDataContext.BulkInsertAsync(providerRegistrationDetails);
+                await _roatpDataContext.ImportAudits.AddAsync(new ImportAudit(timeStarted, providerRegistrationDetails.Count, ImportType.ProviderRegistrationDetails));
                 await _roatpDataContext.SaveChangesAsync();
                 await transaction.CommitAsync();
             }

--- a/src/SFA.DAS.Roatp.Database/Tables/ProvderRegistrationDetail.sql
+++ b/src/SFA.DAS.Roatp.Database/Tables/ProvderRegistrationDetail.sql
@@ -1,15 +1,17 @@
 ﻿CREATE TABLE [dbo].[ProviderRegistrationDetail]
 (
-    [Ukprn] INT NOT NULL PRIMARY KEY, 
+    [Ukprn] INT NOT NULL PRIMARY KEY,
     [LegalName] VARCHAR(1000) NOT NULL,
-    [StatusId] INT NOT NULL, 
-    [StatusDate] DATETIME2 NOT NULL, 
-    [OrganisationTypeId] INT NOT NULL, 
-    [ProviderTypeId] INT NOT NULL, 
-    [AddressLine1] VARCHAR(250) NULL, 
+    [StatusId] INT NOT NULL,
+    [StatusDate] DATETIME2 NOT NULL,
+    [OrganisationTypeId] INT NOT NULL,
+    [ProviderTypeId] INT NOT NULL,
+    [AddressLine1] VARCHAR(250) NULL,
     [AddressLine2] VARCHAR(250) NULL,
     [AddressLine3] VARCHAR(250) NULL,
-    [AddressLine4] VARCHAR(250) NULL, 
-    [Town] VARCHAR(250) NULL, 
-    [Postcode] VARCHAR(25) NULL
+    [AddressLine4] VARCHAR(250) NULL,
+    [Town] VARCHAR(250) NULL,
+    [Postcode] VARCHAR(25) NULL,
+    [Latitude] FLOAT NULL,
+    [Longitude] FLOAT NULL
 )

--- a/src/SFA.DAS.Roatp.Database/Tables/ProvderRegistrationDetail.sql
+++ b/src/SFA.DAS.Roatp.Database/Tables/ProvderRegistrationDetail.sql
@@ -6,4 +6,10 @@
     [StatusDate] DATETIME2 NOT NULL, 
     [OrganisationTypeId] INT NOT NULL, 
     [ProviderTypeId] INT NOT NULL, 
+    [AddressLine1] VARCHAR(250) NULL, 
+    [AddressLine2] VARCHAR(250) NULL,
+    [AddressLine3] VARCHAR(250) NULL,
+    [AddressLine4] VARCHAR(250) NULL, 
+    [Town] VARCHAR(250) NULL, 
+    [Postcode] VARCHAR(25) NULL
 )

--- a/src/SFA.DAS.Roatp.Database/Tables/Provider.sql
+++ b/src/SFA.DAS.Roatp.Database/Tables/Provider.sql
@@ -13,5 +13,6 @@
     [IsImported] BIT NOT NULL DEFAULT 0,
 
     CONSTRAINT PK_Provider PRIMARY KEY (Id),
-    CONSTRAINT UK_Provider_Ukprn UNIQUE (Ukprn)
+    CONSTRAINT UK_Provider_Ukprn UNIQUE (Ukprn),
+    INDEX IX_Provider_Ukrpn NONCLUSTERED (Ukprn)
 )

--- a/src/SFA.DAS.Roatp.Domain.UnitTests/Entities/ProviderRegistraionDetailTests.cs
+++ b/src/SFA.DAS.Roatp.Domain.UnitTests/Entities/ProviderRegistraionDetailTests.cs
@@ -1,7 +1,7 @@
-﻿using AutoFixture.NUnit3;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using SFA.DAS.Roatp.Domain.Entities;
 using SFA.DAS.Roatp.Domain.Models;
+using SFA.DAS.Testing.AutoFixture;
 
 namespace SFA.DAS.Roatp.Domain.UnitTests.Entities
 {
@@ -9,7 +9,7 @@ namespace SFA.DAS.Roatp.Domain.UnitTests.Entities
     public class ProviderRegistraionDetailTests
     {
         [Test]
-        [AutoData]
+        [RecursiveMoqAutoData]
         public void UpdateAddress_UpdatesAddressFromModel(UkrlpProviderAddress source, ProviderRegistrationDetail sut)
         {
             sut.UpdateAddress(source);

--- a/src/SFA.DAS.Roatp.Domain.UnitTests/Entities/ProviderRegistraionDetailTests.cs
+++ b/src/SFA.DAS.Roatp.Domain.UnitTests/Entities/ProviderRegistraionDetailTests.cs
@@ -1,0 +1,25 @@
+﻿using AutoFixture.NUnit3;
+using NUnit.Framework;
+using SFA.DAS.Roatp.Domain.Entities;
+using SFA.DAS.Roatp.Domain.Models;
+
+namespace SFA.DAS.Roatp.Domain.UnitTests.Entities
+{
+    [TestFixture]
+    public class ProviderRegistraionDetailTests
+    {
+        [Test]
+        [AutoData]
+        public void UpdateAddress_UpdatesAddressFromModel(UkrlpProviderAddress source, ProviderRegistrationDetail sut)
+        {
+            sut.UpdateAddress(source);
+
+            Assert.That(sut.AddressLine1, Is.EqualTo(source.Address1));
+            Assert.That(sut.AddressLine2, Is.EqualTo(source.Address2));
+            Assert.That(sut.AddressLine3, Is.EqualTo(source.Address3));
+            Assert.That(sut.AddressLine4, Is.EqualTo(source.Address4));
+            Assert.That(sut.Town, Is.EqualTo(source.Town));
+            Assert.That(sut.Postcode, Is.EqualTo(source.Postcode));
+        }
+    }
+}

--- a/src/SFA.DAS.Roatp.Domain/Entities/ImportAudit.cs
+++ b/src/SFA.DAS.Roatp.Domain/Entities/ImportAudit.cs
@@ -12,14 +12,6 @@ namespace SFA.DAS.Roatp.Domain.Entities
             TimeFinished = DateTime.UtcNow;
         }
 
-        public ImportAudit(DateTime timeStarted, int rowsImported, ImportType importType, DateTime timeFinished)
-        {
-            TimeStarted = timeStarted;
-            RowsImported = rowsImported;
-            ImportType = importType;
-            TimeFinished = timeFinished;
-        }
-
         public int Id { get; set; }
         public DateTime TimeStarted { get; set; }
         public DateTime TimeFinished { get; set; }
@@ -32,6 +24,7 @@ namespace SFA.DAS.Roatp.Domain.Entities
         CourseDirectory,
         ProviderRegistrationDetails,
         ProviderRegistrationAddresses,
+        ProviderRegistrationAddressCoordinates,
         Standards,
         NationalAchievementRates,
         NationalAchievementRatesOverall,

--- a/src/SFA.DAS.Roatp.Domain/Entities/ImportAudit.cs
+++ b/src/SFA.DAS.Roatp.Domain/Entities/ImportAudit.cs
@@ -29,8 +29,9 @@ namespace SFA.DAS.Roatp.Domain.Entities
 
     public enum ImportType
     {
-        CourseDirectory, 
-        ProviderRegistrationDetails, 
+        CourseDirectory,
+        ProviderRegistrationDetails,
+        ProviderRegistrationAddresses,
         Standards,
         NationalAchievementRates,
         NationalAchievementRatesOverall,

--- a/src/SFA.DAS.Roatp.Domain/Entities/Provider.cs
+++ b/src/SFA.DAS.Roatp.Domain/Entities/Provider.cs
@@ -23,6 +23,7 @@ namespace SFA.DAS.Roatp.Domain.Entities
         public virtual List<NationalAchievementRate> NationalAchievementRates { get; set; } = new List<NationalAchievementRate>();
 
 
-        public virtual ProviderAddress ProviderAddress { get; set; } 
+        public virtual ProviderAddress ProviderAddress { get; set; }
+        public virtual ProviderRegistrationDetail ProviderRegistrationDetail { get; set; }
     }
 }

--- a/src/SFA.DAS.Roatp.Domain/Entities/ProviderRegistrationDetail.cs
+++ b/src/SFA.DAS.Roatp.Domain/Entities/ProviderRegistrationDetail.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using SFA.DAS.Roatp.Domain.Models;
 
 namespace SFA.DAS.Roatp.Domain.Entities
 {
@@ -10,5 +11,21 @@ namespace SFA.DAS.Roatp.Domain.Entities
         public int OrganisationTypeId { get; set; }
         public int ProviderTypeId { get; set; }
         public string LegalName { get; set; }
+        public string AddressLine1 { get; set; }
+        public string AddressLine2 { get; set; }
+        public string AddressLine3 { get; set; }
+        public string AddressLine4 { get; set; }
+        public string Town { get; set; }
+        public string Postcode { get; set; }
+
+        public void UpdateAddress(UkrlpProviderAddress source)
+        {
+            AddressLine1 = source.Address1;
+            AddressLine2 = source.Address2;
+            AddressLine3 = source.Address3;
+            AddressLine4 = source.Address4;
+            Town = source.Town;
+            Postcode = source.Postcode;
+        }
     }
 }

--- a/src/SFA.DAS.Roatp.Domain/Entities/ProviderRegistrationDetail.cs
+++ b/src/SFA.DAS.Roatp.Domain/Entities/ProviderRegistrationDetail.cs
@@ -21,6 +21,8 @@ namespace SFA.DAS.Roatp.Domain.Entities
         public double? Longitude { get; set; }
 
 
+        public virtual Provider Provider { get; set; }
+
         public void UpdateAddress(UkrlpProviderAddress source)
         {
             AddressLine1 = source.Address1;

--- a/src/SFA.DAS.Roatp.Domain/Entities/ProviderRegistrationDetail.cs
+++ b/src/SFA.DAS.Roatp.Domain/Entities/ProviderRegistrationDetail.cs
@@ -17,6 +17,9 @@ namespace SFA.DAS.Roatp.Domain.Entities
         public string AddressLine4 { get; set; }
         public string Town { get; set; }
         public string Postcode { get; set; }
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+
 
         public void UpdateAddress(UkrlpProviderAddress source)
         {

--- a/src/SFA.DAS.Roatp.Domain/Interfaces/IProviderRegistrationDetailsWriteRepository.cs
+++ b/src/SFA.DAS.Roatp.Domain/Interfaces/IProviderRegistrationDetailsWriteRepository.cs
@@ -8,6 +8,6 @@ namespace SFA.DAS.Roatp.Domain.Interfaces
     public interface IProviderRegistrationDetailsWriteRepository
     {
         Task<List<ProviderRegistrationDetail>> GetActiveProviders();
-        Task UpdateProviders(DateTime timeStarted, int providerCount);
+        Task UpdateProviders(DateTime timeStarted, int providerCount, ImportType importType);
     }
 }

--- a/src/SFA.DAS.Roatp.Domain/Interfaces/IProviderRegistrationDetailsWriteRepository.cs
+++ b/src/SFA.DAS.Roatp.Domain/Interfaces/IProviderRegistrationDetailsWriteRepository.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SFA.DAS.Roatp.Domain.Entities;
+
+namespace SFA.DAS.Roatp.Domain.Interfaces
+{
+    public interface IProviderRegistrationDetailsWriteRepository
+    {
+        Task<List<ProviderRegistrationDetail>> GetActiveProviders();
+        Task UpdateProviders(DateTime timeStarted, int providerCount);
+    }
+}

--- a/src/SFA.DAS.Roatp.Domain/Interfaces/IReloadProviderRegistrationDetailsRepository.cs
+++ b/src/SFA.DAS.Roatp.Domain/Interfaces/IReloadProviderRegistrationDetailsRepository.cs
@@ -1,11 +1,12 @@
-﻿using SFA.DAS.Roatp.Domain.Entities;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using SFA.DAS.Roatp.Domain.Entities;
 
 namespace SFA.DAS.Roatp.Domain.Interfaces
 {
     public interface IReloadProviderRegistrationDetailsRepository
     {
-        Task<bool> ReloadRegisteredProviders(List<ProviderRegistrationDetail> providerRegistrationDetails);
+        Task<bool> ReloadRegisteredProviders(List<ProviderRegistrationDetail> providerRegistrationDetails, DateTime timeStarted);
     }
 }

--- a/src/SFA.DAS.Roatp.Jobs.UnitTests/Services/ReloadProviderRegistrationDetailServiceTests.cs
+++ b/src/SFA.DAS.Roatp.Jobs.UnitTests/Services/ReloadProviderRegistrationDetailServiceTests.cs
@@ -31,7 +31,7 @@ namespace SFA.DAS.Roatp.Jobs.UnitTests.Services
         }
 
         [Test]
-        [MoqAutoData]
+        [RecursiveMoqAutoData]
         public async Task ReloadProviderRegistrationDetails_OnApiSuccess_CallsRepositoryReloadMethod(
             [Frozen] Mock<IReloadProviderRegistrationDetailsRepository> repositoryMock,
             [Frozen] Mock<ICourseManagementOuterApiClient> apiClientMock,

--- a/src/SFA.DAS.Roatp.Jobs.UnitTests/Services/ReloadProviderRegistrationDetailServiceTests.cs
+++ b/src/SFA.DAS.Roatp.Jobs.UnitTests/Services/ReloadProviderRegistrationDetailServiceTests.cs
@@ -1,4 +1,7 @@
-﻿using AutoFixture.NUnit3;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoFixture.NUnit3;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -7,9 +10,6 @@ using SFA.DAS.Roatp.Domain.Interfaces;
 using SFA.DAS.Roatp.Jobs.ApiClients;
 using SFA.DAS.Roatp.Jobs.Services;
 using SFA.DAS.Testing.AutoFixture;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.Roatp.Jobs.UnitTests.Services
 {
@@ -24,7 +24,7 @@ namespace SFA.DAS.Roatp.Jobs.UnitTests.Services
             [Greedy] ReloadProviderRegistrationDetailService sut)
         {
             apiClientMock.Setup(a => a.Get<List<ProviderRegistrationDetail>>("lookup/registered-providers")).ReturnsAsync((false, null));
-            
+
             Func<Task> action = () => sut.ReloadProviderRegistrationDetails();
 
             await action.Should().ThrowAsync<InvalidOperationException>();
@@ -34,7 +34,6 @@ namespace SFA.DAS.Roatp.Jobs.UnitTests.Services
         [MoqAutoData]
         public async Task ReloadProviderRegistrationDetails_OnApiSuccess_CallsRepositoryReloadMethod(
             [Frozen] Mock<IReloadProviderRegistrationDetailsRepository> repositoryMock,
-            [Frozen] Mock<IImportAuditWriteRepository> auditRepositoryMock,
             [Frozen] Mock<ICourseManagementOuterApiClient> apiClientMock,
             [Greedy] ReloadProviderRegistrationDetailService sut,
             List<ProviderRegistrationDetail> data)
@@ -43,8 +42,7 @@ namespace SFA.DAS.Roatp.Jobs.UnitTests.Services
 
             await sut.ReloadProviderRegistrationDetails();
 
-            repositoryMock.Verify(r => r.ReloadRegisteredProviders(data));
-            auditRepositoryMock.Verify(x=>x.Insert(It.IsAny<ImportAudit>()));
+            repositoryMock.Verify(r => r.ReloadRegisteredProviders(data, It.IsAny<DateTime>()));
         }
     }
 }

--- a/src/SFA.DAS.Roatp.Jobs/Functions/ReloadProviderRegistrationDetailsFunction.cs
+++ b/src/SFA.DAS.Roatp.Jobs/Functions/ReloadProviderRegistrationDetailsFunction.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Jobs.Services;
@@ -15,13 +16,23 @@ namespace SFA.DAS.Roatp.Jobs.Functions
         }
 
         [FunctionName(nameof(ReloadProviderRegistrationDetailsFunction))]
-        public async Task Run([TimerTrigger("%ReloadProviderRegistrationDetailsSchedule%")] TimerInfo myTimer, ILogger log)
+        public async Task Run([TimerTrigger("%ReloadProviderRegistrationDetailsSchedule%", RunOnStartup = false)] TimerInfo myTimer, ILogger log)
         {
             log.LogInformation("ReloadProviderRegistrationDetailsFunction function started");
+
+            var startTime = DateTime.Now;
             await _service.ReloadProviderRegistrationDetails();
-            //Below step is dependent on the step above so cannot run it in parallel 
+            log.LogInformation($"Reload register completed in {(DateTime.Now - startTime).TotalMilliseconds} ms");
+
+            startTime = DateTime.Now;
             await _service.ReloadAllAddresses();
-            log.LogInformation("Provider registration details reload complete");
+            log.LogInformation($"Reload registered provider address completed in {(DateTime.Now - startTime).TotalMilliseconds} ms");
+
+            startTime = DateTime.Now;
+            await _service.ReloadAllCoordinates();
+            log.LogInformation($"Reload register provider address coordinates completed in {(DateTime.Now - startTime).TotalMilliseconds}ms");
+
+            log.LogInformation($"ReloadProviderRegistrationDetailsFunction function finished");
         }
     }
 }

--- a/src/SFA.DAS.Roatp.Jobs/Functions/ReloadProviderRegistrationDetailsFunction.cs
+++ b/src/SFA.DAS.Roatp.Jobs/Functions/ReloadProviderRegistrationDetailsFunction.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Azure.WebJobs;
+﻿using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Jobs.Services;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.Roatp.Jobs.Functions
 {
@@ -19,6 +19,8 @@ namespace SFA.DAS.Roatp.Jobs.Functions
         {
             log.LogInformation("ReloadProviderRegistrationDetailsFunction function started");
             await _service.ReloadProviderRegistrationDetails();
+            //Below step is dependent on the step above so cannot run it in parallel 
+            await _service.ReloadAllAddresses();
             log.LogInformation("Provider registration details reload complete");
         }
     }

--- a/src/SFA.DAS.Roatp.Jobs/Functions/UpdateProviderAddressCoordinatesFunction.cs
+++ b/src/SFA.DAS.Roatp.Jobs/Functions/UpdateProviderAddressCoordinatesFunction.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Azure.WebJobs;
-using SFA.DAS.Roatp.Jobs.Services;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using SFA.DAS.Roatp.Jobs.Services;
 
 namespace SFA.DAS.Roatp.Jobs.Functions
 {
@@ -15,7 +15,7 @@ namespace SFA.DAS.Roatp.Jobs.Functions
         }
 
         [FunctionName(nameof(UpdateProviderAddressCoordinatesFunction))]
-        public async Task Run([TimerTrigger("%UpdateProviderAddressCoordinatesSchedule%",RunOnStartup = true)] TimerInfo myTimer, ILogger log)
+        public async Task Run([TimerTrigger("%UpdateProviderAddressCoordinatesSchedule%", RunOnStartup = false)] TimerInfo myTimer, ILogger log)
         {
             log.LogInformation("UpdateProviderAddressCoordinatesFunction function started");
             await _updateProviderAddressCoordinatesService.UpdateProviderAddressCoordinates();

--- a/src/SFA.DAS.Roatp.Jobs/Services/IReloadProviderRegistrationDetailService.cs
+++ b/src/SFA.DAS.Roatp.Jobs/Services/IReloadProviderRegistrationDetailService.cs
@@ -6,5 +6,6 @@ namespace SFA.DAS.Roatp.Jobs.Services
     {
         Task ReloadProviderRegistrationDetails();
         Task ReloadAllAddresses();
+        Task ReloadAllCoordinates();
     }
 }

--- a/src/SFA.DAS.Roatp.Jobs/Services/IReloadProviderRegistrationDetailService.cs
+++ b/src/SFA.DAS.Roatp.Jobs/Services/IReloadProviderRegistrationDetailService.cs
@@ -5,5 +5,6 @@ namespace SFA.DAS.Roatp.Jobs.Services
     public interface IReloadProviderRegistrationDetailService
     {
         Task ReloadProviderRegistrationDetails();
+        Task ReloadAllAddresses();
     }
 }

--- a/src/SFA.DAS.Roatp.Jobs/Services/ReloadProviderRegistrationDetailService.cs
+++ b/src/SFA.DAS.Roatp.Jobs/Services/ReloadProviderRegistrationDetailService.cs
@@ -1,25 +1,30 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Domain.Entities;
 using SFA.DAS.Roatp.Domain.Interfaces;
+using SFA.DAS.Roatp.Domain.Models;
 using SFA.DAS.Roatp.Jobs.ApiClients;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+using SFA.DAS.Roatp.Jobs.Requests;
 
 namespace SFA.DAS.Roatp.Jobs.Services
 {
     public class ReloadProviderRegistrationDetailService : IReloadProviderRegistrationDetailService
     {
-        private readonly IReloadProviderRegistrationDetailsRepository _repository;
+        private readonly IProviderRegistrationDetailsWriteRepository _providerRegistrationDetailsWriteRepository;
+        private readonly IReloadProviderRegistrationDetailsRepository _reloadProviderRegistrationDetailsRepository;
         private readonly ICourseManagementOuterApiClient _courseManagementOuterApiClient;
         private readonly ILogger<ReloadProviderRegistrationDetailService> _logger;
         private readonly IImportAuditWriteRepository _importAuditWriteRepository;
-        public ReloadProviderRegistrationDetailService(IReloadProviderRegistrationDetailsRepository repository, ICourseManagementOuterApiClient courseManagementOuterApiClient, IImportAuditWriteRepository importAuditWriteRepository, ILogger<ReloadProviderRegistrationDetailService> logger)
+        public ReloadProviderRegistrationDetailService(IReloadProviderRegistrationDetailsRepository reloadProviderRegistrationDetailsRepository, ICourseManagementOuterApiClient courseManagementOuterApiClient, IImportAuditWriteRepository importAuditWriteRepository, ILogger<ReloadProviderRegistrationDetailService> logger, IProviderRegistrationDetailsWriteRepository providerRegistrationDetailsWriteRepository)
         {
-            _repository = repository;
+            _reloadProviderRegistrationDetailsRepository = reloadProviderRegistrationDetailsRepository;
             _courseManagementOuterApiClient = courseManagementOuterApiClient;
             _importAuditWriteRepository = importAuditWriteRepository;
             _logger = logger;
+            _providerRegistrationDetailsWriteRepository = providerRegistrationDetailsWriteRepository;
         }
 
         public async Task ReloadProviderRegistrationDetails()
@@ -33,8 +38,45 @@ namespace SFA.DAS.Roatp.Jobs.Services
                 throw new InvalidOperationException(errorMessage);
             }
             _logger.LogInformation($"Reloading {providerRegistrationDetails.Count} provider registration details");
-            await _repository.ReloadRegisteredProviders(providerRegistrationDetails);
+            await _reloadProviderRegistrationDetailsRepository.ReloadRegisteredProviders(providerRegistrationDetails);
             await _importAuditWriteRepository.Insert(new ImportAudit(timeStarted, providerRegistrationDetails.Count, ImportType.ProviderRegistrationDetails));
+        }
+
+        public async Task ReloadAllAddresses()
+        {
+            var timeStarted = DateTime.UtcNow;
+            var activeProvidersOnRegister = await _providerRegistrationDetailsWriteRepository.GetActiveProviders();
+
+            var ukprnsSubset = activeProvidersOnRegister.Select(provider => provider.Ukprn).ToList();
+
+            var request = new ProviderAddressLookupRequest
+            {
+                Ukprns = ukprnsSubset
+            };
+
+            var (success, ukrlpResponse) = await _courseManagementOuterApiClient.Post<ProviderAddressLookupRequest, List<UkrlpProviderAddress>>("lookup/providers-address", request);
+
+            if (!success || !ukrlpResponse.Any())
+            {
+                _logger.LogError($"LoadAllProviderAddressesFunction function failed to get ukrlp addresses");
+                return;
+            }
+
+            foreach (var activeProvider in activeProvidersOnRegister)
+            {
+                var ukrlpProvider = ukrlpResponse.FirstOrDefault(x => x.Ukprn == activeProvider.Ukprn);
+                if (ukrlpProvider == null)
+                {
+                    _logger.LogWarning($"Unable to get address from UKRLP for provider ukprn: {activeProvider.Ukprn}");
+                    continue;
+
+                }
+                activeProvider.UpdateAddress(ukrlpProvider);
+            }
+
+            await _providerRegistrationDetailsWriteRepository.UpdateProviders(timeStarted, ukrlpResponse.Count);
+
+            _logger.LogInformation("Provider registration addresses reload complete");
         }
     }
 }

--- a/src/SFA.DAS.Roatp.Jobs/Services/ReloadProviderRegistrationDetailService.cs
+++ b/src/SFA.DAS.Roatp.Jobs/Services/ReloadProviderRegistrationDetailService.cs
@@ -14,16 +14,19 @@ namespace SFA.DAS.Roatp.Jobs.Services
 {
     public class ReloadProviderRegistrationDetailService : IReloadProviderRegistrationDetailService
     {
-        private readonly IProviderRegistrationDetailsWriteRepository _providerRegistrationDetailsWriteRepository;
         private readonly IReloadProviderRegistrationDetailsRepository _reloadProviderRegistrationDetailsRepository;
         private readonly ICourseManagementOuterApiClient _courseManagementOuterApiClient;
         private readonly ILogger<ReloadProviderRegistrationDetailService> _logger;
-        private readonly IImportAuditWriteRepository _importAuditWriteRepository;
-        public ReloadProviderRegistrationDetailService(IReloadProviderRegistrationDetailsRepository reloadProviderRegistrationDetailsRepository, ICourseManagementOuterApiClient courseManagementOuterApiClient, IImportAuditWriteRepository importAuditWriteRepository, ILogger<ReloadProviderRegistrationDetailService> logger, IProviderRegistrationDetailsWriteRepository providerRegistrationDetailsWriteRepository)
+        private readonly IProviderRegistrationDetailsWriteRepository _providerRegistrationDetailsWriteRepository;
+
+        public ReloadProviderRegistrationDetailService(
+            IReloadProviderRegistrationDetailsRepository reloadProviderRegistrationDetailsRepository,
+            ICourseManagementOuterApiClient courseManagementOuterApiClient,
+            ILogger<ReloadProviderRegistrationDetailService> logger,
+            IProviderRegistrationDetailsWriteRepository providerRegistrationDetailsWriteRepository)
         {
             _reloadProviderRegistrationDetailsRepository = reloadProviderRegistrationDetailsRepository;
             _courseManagementOuterApiClient = courseManagementOuterApiClient;
-            _importAuditWriteRepository = importAuditWriteRepository;
             _logger = logger;
             _providerRegistrationDetailsWriteRepository = providerRegistrationDetailsWriteRepository;
         }

--- a/src/SFA.DAS.Roatp.Jobs/local.settings.json
+++ b/src/SFA.DAS.Roatp.Jobs/local.settings.json
@@ -5,6 +5,13 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
     "EnvironmentName": "LOCAL",
-    "LoggingRedisConnectionString": "localhost"
+    "LoggingRedisConnectionString": "localhost",
+    "AzureWebJobs.LoadAllProviderAddressesFunction.Disabled": true,
+    "AzureWebJobs.LoadCourseDirectoryDataFunction.Disabled": true,
+    "AzureWebJobs.LoadProvidersAddressFunction.Disabled": false,
+    "AzureWebJobs.ReloadNationalAcheivementRatesFunction.Disabled": false,
+    "AzureWebJobs.ReloadProviderRegistrationDetailsFunction.Disabled": false,
+    "AzureWebJobs.ReloadStandardsCacheFunction.Disabled": false,
+    "AzureWebJobs.UpdateProviderAddressCoordinatesFunction.Disabled": false
   }
 }


### PR DESCRIPTION
This PR was put together to quickly fix the production issue found in recruit where recruit was expecting to get back all the providers, however this endpoint was only returning the providers who were successfully imported in the Provider table. 

Recruit was also expecting to get back provider address along with the register, but we only hold addresses of the providers who are in Provider table. To get the addresses for all the providers on the register, I had to add the address fields to the `ProviderRegistrationDetail` table and populate it as part of Reload function. 

I don't like the changes that I had to put in to fix the production issue, a proper solution would be that recruit should talk to Roatp Service  however that would take long time to resolve and this is the short term solution forced down. 

There is a lot of tech debt added along with missing coverage as part of this **quick** change and I have created a task [ CSP-614 ](https://skillsfundingagency.atlassian.net/browse/CSP-614) to address this.