### PR TITLE
CSP-2059 Restores old endpoint and changes route on new endpoint

### DIFF
--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
@@ -1,4 +1,7 @@
-﻿using MediatR;
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -7,9 +10,7 @@ using SFA.DAS.Roatp.Application.ProviderCourse.Queries.GetAllProviderCourses;
 using SFA.DAS.Roatp.Application.ProviderCourse.Queries.GetProviderCourse;
 using SFA.DAS.Roatp.Application.Providers.Queries.GetProviders;
 using SFA.DAS.Roatp.Application.Providers.Queries.GetProviderSummary;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
+using SFA.DAS.Roatp.Application.Providers.Queries.GetRegisteredProvider;
 
 namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
 {
@@ -33,7 +34,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         public async Task<IActionResult> GetProviders([FromQuery] bool? Live, CancellationToken cancellationToken)
         {
             var providerResult = await _mediator.Send(
-                new GetProvidersQuery() { Live = Live ?? false }, 
+                new GetProvidersQuery() { Live = Live ?? false },
                 cancellationToken
             );
 
@@ -42,7 +43,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         }
 
         [HttpGet]
-        [Route("{ukprn:int}")]
+        [Route("{ukprn:int}/summary")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetProviderSummaryQueryResult), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetProviderSummary([FromRoute] int ukprn)
@@ -50,6 +51,15 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
             return GetResponse(
                 await _mediator.Send(new GetProviderSummaryQuery(ukprn))
             );
+        }
+
+        [HttpGet]
+        [Route("{ukprn:int}")]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(GetProviderSummaryQueryResult), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetRegisteredProvider([FromRoute] int ukprn, CancellationToken cancellationToken)
+        {
+            return GetResponse(await _mediator.Send(new GetRegisteredProviderQuery(ukprn), cancellationToken));
         }
 
         /// <summary>

--- a/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetProvider/GetProviderQueryHandlerTests.cs
+++ b/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetProvider/GetProviderQueryHandlerTests.cs
@@ -9,28 +9,27 @@ using SFA.DAS.Roatp.Domain.Entities;
 using SFA.DAS.Roatp.Domain.Interfaces;
 using SFA.DAS.Testing.AutoFixture;
 
-namespace SFA.DAS.Roatp.Application.UnitTests.Providers.Queries.GetProvider
+namespace SFA.DAS.Roatp.Application.UnitTests.Providers.Queries.GetProvider;
+
+[TestFixture]
+public class GetProviderQueryHandlerTests
 {
-    [TestFixture]
-    public class GetProviderQueryHandlerTests
+    [Test, RecursiveMoqAutoData()]
+    public async Task Handle_ReturnsResult(
+        Provider provider,
+        ProviderRegistrationDetail providerRegistrationDetail,
+        [Frozen] Mock<IProvidersReadRepository> repoMockProvidersReadRepository,
+        [Frozen] Mock<IProviderRegistrationDetailsReadRepository> repoMockProviderRegistrationDetailsReadRepository,
+        GetProviderQuery query,
+        GetProviderQueryHandler sut,
+        CancellationToken cancellationToken)
     {
-        [Test, RecursiveMoqAutoData()]
-        public async Task Handle_ReturnsResult(
-            Provider provider,
-            ProviderRegistrationDetail providerRegistrationDetail,
-            [Frozen] Mock<IProvidersReadRepository> repoMockProvidersReadRepository,
-            [Frozen] Mock<IProviderRegistrationDetailsReadRepository> repoMockProviderRegistrationDetailsReadRepository,
-            GetProviderQuery query,
-            GetProviderQueryHandler sut,
-            CancellationToken cancellationToken)
-        {
-            repoMockProvidersReadRepository.Setup(r => r.GetByUkprn(query.Ukprn)).ReturnsAsync(provider);
+        repoMockProvidersReadRepository.Setup(r => r.GetByUkprn(query.Ukprn)).ReturnsAsync(provider);
 
-            repoMockProviderRegistrationDetailsReadRepository.Setup(r => r.GetProviderRegistrationDetail(query.Ukprn)).ReturnsAsync(providerRegistrationDetail);
+        repoMockProviderRegistrationDetailsReadRepository.Setup(r => r.GetProviderRegistrationDetail(query.Ukprn, cancellationToken)).ReturnsAsync(providerRegistrationDetail);
 
-            var result = await sut.Handle(query, cancellationToken);
+        var result = await sut.Handle(query, cancellationToken);
 
-            result.Should().NotBeNull();
-        }
+        result.Should().NotBeNull();
     }
 }

--- a/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQueryHandlerTests.cs
+++ b/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQueryHandlerTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture.NUnit3;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Roatp.Application.Providers.Queries.GetRegisteredProvider;
+using SFA.DAS.Roatp.Domain.Entities;
+using SFA.DAS.Roatp.Domain.Interfaces;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.Roatp.Application.UnitTests.Providers.Queries.GetRegisteredProvider;
+public class GetRegisteredProviderQueryHandlerTests
+{
+    [Test, RecursiveMoqAutoData()]
+    public async Task Handle_ReturnsResult(
+            ProviderRegistrationDetail provider,
+            [Frozen] Mock<IProviderRegistrationDetailsReadRepository> repoMock,
+            GetRegisteredProviderQuery query,
+            GetRegisteredProviderQueryHandler sut,
+            CancellationToken cancellationToken)
+    {
+        repoMock.Setup(r => r.GetProviderRegistrationDetail(query.Ukprn, cancellationToken)).ReturnsAsync(provider);
+        GetRegisteredProviderQueryResult expected = provider;
+
+        var response = await sut.Handle(query, cancellationToken);
+
+        response.Should().NotBeNull();
+        response.Result.Should().BeEquivalentTo(expected);
+    }
+
+    [Test, RecursiveMoqAutoData()]
+    public async Task Handle_ReturnsNullResult(
+        [Frozen] Mock<IProviderRegistrationDetailsReadRepository> repoMock,
+        GetRegisteredProviderQuery query,
+        GetRegisteredProviderQueryHandler sut,
+        CancellationToken cancellationToken)
+    {
+        repoMock.Setup(r => r.GetProviderRegistrationDetail(query.Ukprn, cancellationToken)).ReturnsAsync((ProviderRegistrationDetail)null);
+        var response = await sut.Handle(query, cancellationToken);
+        response.Should().NotBeNull();
+        response.Result.Should().BeNull();
+
+    }
+}

--- a/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQueryValidatorTests.cs
+++ b/src/SFA.DAS.Roatp.Application.UnitTests/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQueryValidatorTests.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Roatp.Application.Providers.Queries.GetRegisteredProvider;
+using SFA.DAS.Roatp.Domain.Entities;
+using SFA.DAS.Roatp.Domain.Interfaces;
+
+namespace SFA.DAS.Roatp.Application.UnitTests.Providers.Queries.GetRegisteredProvider;
+
+public class GetRegisteredProviderQueryValidatorTests
+{
+    [TestCase(10000001, true)]
+    [TestCase(10000000, false)]
+    [TestCase(100000000, false)]
+    public async Task Validate_AcceptsEightDigitNumbersOnly(int ukprn, bool expectedResult)
+    {
+        var query = new GetRegisteredProviderQuery(ukprn);
+        var repoMock = new Mock<IProvidersReadRepository>();
+        repoMock.Setup(x => x.GetByUkprn(It.IsAny<int>())).ReturnsAsync(new Provider());
+        var sut = new GetRegisteredProviderQueryValidator(repoMock.Object);
+
+        var result = await sut.ValidateAsync(query);
+
+        result.IsValid.Should().Be(expectedResult);
+    }
+}

--- a/src/SFA.DAS.Roatp.Application/Mediatr/Responses/ValidatedResponse.cs
+++ b/src/SFA.DAS.Roatp.Application/Mediatr/Responses/ValidatedResponse.cs
@@ -1,15 +1,15 @@
-﻿using FluentValidation.Results;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using FluentValidation.Results;
 
 namespace SFA.DAS.Roatp.Application.Mediatr.Responses
 {
     public class ValidatedResponse { }
-    
+
     public class ValidatedResponse<T> : ValidatedResponse
     {
-         public T Result { get; }
+        public T Result { get; }
         private readonly IList<ValidationFailure> _errorMessages = new List<ValidationFailure>();
 
         public IReadOnlyCollection<ValidationFailure> Errors => new ReadOnlyCollection<ValidationFailure>(_errorMessages);
@@ -17,6 +17,5 @@ namespace SFA.DAS.Roatp.Application.Mediatr.Responses
 
         public ValidatedResponse(T model) => Result = model;
         public ValidatedResponse(IList<ValidationFailure> validationErrors) => _errorMessages = validationErrors;
-     
     }
 }

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProvider/GetProviderQueryHandler.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetProvider/GetProviderQueryHandler.cs
@@ -1,41 +1,39 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Application.Mediatr.Responses;
 using SFA.DAS.Roatp.Domain.Interfaces;
 using SFA.DAS.Roatp.Domain.Models;
 
-namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProvider
+namespace SFA.DAS.Roatp.Application.Providers.Queries.GetProvider;
+
+public class GetProviderQueryHandler : IRequestHandler<GetProviderQuery, ValidatedResponse<GetProviderQueryResult>>
 {
-    public class GetProviderQueryHandler : IRequestHandler<GetProviderQuery, ValidatedResponse<GetProviderQueryResult>>
+    private readonly IProvidersReadRepository _providersReadRepository;
+    private readonly IProviderRegistrationDetailsReadRepository _providerRegistrationDetailsReadRepository;
+    private readonly ILogger<GetProviderQueryHandler> _logger;
+
+    public GetProviderQueryHandler(IProvidersReadRepository providersReadRepository, ILogger<GetProviderQueryHandler> logger, IProviderRegistrationDetailsReadRepository providerRegistrationDetailsReadRepository)
     {
-        private readonly IProvidersReadRepository _providersReadRepository;
-        private readonly IProviderRegistrationDetailsReadRepository _providerRegistrationDetailsReadRepository;
-        private readonly ILogger<GetProviderQueryHandler> _logger;
+        _providersReadRepository = providersReadRepository;
+        _logger = logger;
+        _providerRegistrationDetailsReadRepository = providerRegistrationDetailsReadRepository;
+    }
 
-        public GetProviderQueryHandler(IProvidersReadRepository providersReadRepository, ILogger<GetProviderQueryHandler> logger, IProviderRegistrationDetailsReadRepository providerRegistrationDetailsReadRepository)
-        {
-            _providersReadRepository = providersReadRepository;
-            _logger = logger;
-            _providerRegistrationDetailsReadRepository = providerRegistrationDetailsReadRepository;
-        }
+    public async Task<ValidatedResponse<GetProviderQueryResult>> Handle(GetProviderQuery request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Getting provider for ukprn:{Ukprn}", request.Ukprn);
+        var provider = await _providersReadRepository.GetByUkprn(request.Ukprn);
+        var getProviderQueryResult = (GetProviderQueryResult)provider;
+        var providerRegistrationDetail = await _providerRegistrationDetailsReadRepository.GetProviderRegistrationDetail(request.Ukprn, cancellationToken);
 
-        public async Task<ValidatedResponse<GetProviderQueryResult>> Handle(GetProviderQuery request, CancellationToken cancellationToken)
+        if (providerRegistrationDetail != null)
         {
-            _logger.LogInformation("Getting provider for ukprn [{ukprn}]", request.Ukprn);
-            var provider = await _providersReadRepository.GetByUkprn(request.Ukprn);
-            var getProviderQueryResult = (GetProviderQueryResult)provider;
-            var providerRegistrationDetail = await _providerRegistrationDetailsReadRepository.GetProviderRegistrationDetail(request.Ukprn);
-        
-            if (providerRegistrationDetail != null)
-            {
-                getProviderQueryResult.ProviderType = (ProviderType)providerRegistrationDetail.ProviderTypeId;
-                getProviderQueryResult.ProviderStatusType = (ProviderStatusType)providerRegistrationDetail.StatusId;
-                getProviderQueryResult.ProviderStatusUpdatedDate = providerRegistrationDetail.StatusDate;
-            }
-            return new ValidatedResponse<GetProviderQueryResult>(getProviderQueryResult);
+            getProviderQueryResult.ProviderType = (ProviderType)providerRegistrationDetail.ProviderTypeId;
+            getProviderQueryResult.ProviderStatusType = (ProviderStatusType)providerRegistrationDetail.StatusId;
+            getProviderQueryResult.ProviderStatusUpdatedDate = providerRegistrationDetail.StatusDate;
         }
+        return new ValidatedResponse<GetProviderQueryResult>(getProviderQueryResult);
     }
 }

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQuery.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQuery.cs
@@ -1,0 +1,6 @@
+﻿using MediatR;
+using SFA.DAS.Roatp.Application.Mediatr.Responses;
+
+namespace SFA.DAS.Roatp.Application.Providers.Queries.GetRegisteredProvider;
+
+public record GetRegisteredProviderQuery(int Ukprn) : IRequest<ValidatedResponse<GetRegisteredProviderQueryResult>>;

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQueryHandler.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQueryHandler.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using SFA.DAS.Roatp.Application.Mediatr.Responses;
+using SFA.DAS.Roatp.Domain.Entities;
+using SFA.DAS.Roatp.Domain.Interfaces;
+
+namespace SFA.DAS.Roatp.Application.Providers.Queries.GetRegisteredProvider;
+
+public class GetRegisteredProviderQueryHandler(IProviderRegistrationDetailsReadRepository _providersRegistrationDetailReadRepository) : IRequestHandler<GetRegisteredProviderQuery, ValidatedResponse<GetRegisteredProviderQueryResult>>
+{
+    public async Task<ValidatedResponse<GetRegisteredProviderQueryResult>> Handle(GetRegisteredProviderQuery request, CancellationToken cancellationToken)
+    {
+        ProviderRegistrationDetail providerSummary = await _providersRegistrationDetailReadRepository.GetProviderRegistrationDetail(request.Ukprn, cancellationToken);
+
+        return new ValidatedResponse<GetRegisteredProviderQueryResult>(providerSummary);
+    }
+}

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQueryResult.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQueryResult.cs
@@ -1,0 +1,37 @@
+﻿using SFA.DAS.Roatp.Application.Providers.Queries.GetProviders;
+using SFA.DAS.Roatp.Domain.Entities;
+using SFA.DAS.Roatp.Domain.Models;
+
+namespace SFA.DAS.Roatp.Application.Providers.Queries.GetRegisteredProvider;
+
+public class GetRegisteredProviderQueryResult
+{
+    public int Ukprn { get; set; }
+    public string Name { get; set; }
+    public string TradingName { get; set; }
+    public string Email { get; set; }
+    public string Phone { get; set; }
+    public string ContactUrl { get; set; }
+    public int ProviderTypeId { get; set; }
+    public int StatusId { get; set; }
+    /// <summary>
+    /// Read only property to get the value of Provider can access Apprenticeship Service.
+    /// </summary>
+    public bool CanAccessApprenticeshipService => (ProviderType)ProviderTypeId is ProviderType.Main or ProviderType.Employer
+                                                  && (ProviderStatusType)StatusId is ProviderStatusType.Active or ProviderStatusType.Onboarding or ProviderStatusType.ActiveButNotTakingOnApprentices;
+    public ProviderAddressModel Address { get; set; } = new ProviderAddressModel();
+
+    public static implicit operator GetRegisteredProviderQueryResult(ProviderRegistrationDetail source) =>
+        source == null ? null : new GetRegisteredProviderQueryResult
+        {
+            Ukprn = source.Ukprn,
+            Name = source.LegalName,
+            TradingName = source.Provider?.TradingName,
+            Email = source.Provider?.Email,
+            Phone = source.Provider?.Phone,
+            ContactUrl = source.Provider?.Website,
+            ProviderTypeId = source.ProviderTypeId,
+            StatusId = source.StatusId,
+            Address = source
+        };
+}

--- a/src/SFA.DAS.Roatp.Application/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQueryValidator.cs
+++ b/src/SFA.DAS.Roatp.Application/Providers/Queries/GetRegisteredProvider/GetRegisteredProviderQueryValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+using SFA.DAS.Roatp.Domain.Interfaces;
+
+namespace SFA.DAS.Roatp.Application.Providers.Queries.GetRegisteredProvider;
+
+public class GetRegisteredProviderQueryValidator : AbstractValidator<GetRegisteredProviderQuery>
+{
+    public const string InvalidUkprnErrorMessage = "Invalid ukprn";
+    public const string ProviderNotFoundErrorMessage = "No provider found with given ukprn";
+    public GetRegisteredProviderQueryValidator(IProvidersReadRepository providersReadRepository)
+    {
+        RuleFor(x => x.Ukprn)
+            .Cascade(CascadeMode.Stop)
+            .GreaterThan(10000000).WithMessage(InvalidUkprnErrorMessage)
+            .LessThan(99999999).WithMessage(InvalidUkprnErrorMessage);
+    }
+}

--- a/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsReadRepository.cs
+++ b/src/SFA.DAS.Roatp.Data/Repositories/ProviderRegistrationDetailsReadRepository.cs
@@ -64,7 +64,7 @@ namespace SFA.DAS.Roatp.Data.Repositories
         }
 
         [ExcludeFromCodeCoverage]
-        public async Task<ProviderRegistrationDetail> GetProviderRegistrationDetail(int ukprn)
+        public async Task<ProviderRegistrationDetail> GetProviderRegistrationDetail(int ukprn, CancellationToken cancellationToken)
             => await _roatpDataContext
                     .ProviderRegistrationDetails
                     .Where(x =>
@@ -73,7 +73,7 @@ namespace SFA.DAS.Roatp.Data.Repositories
                         x.StatusId == OrganisationStatus.Onboarding)
                     .Include(r => r.Provider)
                     .AsNoTracking()
-                    .SingleOrDefaultAsync(p => p.Ukprn == ukprn);
+                    .SingleOrDefaultAsync(p => p.Ukprn == ukprn, cancellationToken);
 
         [ExcludeFromCodeCoverage]
         public async Task<bool> IsMainActiveProvider(int ukprn, int larsCode)

--- a/src/SFA.DAS.Roatp.Domain/Interfaces/IProviderRegistrationDetailsReadRepository.cs
+++ b/src/SFA.DAS.Roatp.Domain/Interfaces/IProviderRegistrationDetailsReadRepository.cs
@@ -10,7 +10,7 @@ public interface IProviderRegistrationDetailsReadRepository
 {
     Task<List<ProviderRegistrationDetail>> GetActiveProviderRegistrations(CancellationToken cancellationToken);
     Task<List<ProviderRegistrationDetail>> GetActiveAndMainProviderRegistrations(CancellationToken cancellationToken);
-    Task<ProviderRegistrationDetail> GetProviderRegistrationDetail(int ukprn);
+    Task<ProviderRegistrationDetail> GetProviderRegistrationDetail(int ukprn, CancellationToken cancellationToken);
     Task<bool> IsMainActiveProvider(int ukprn, int larsCode);
     Task<ProviderSummaryModel> GetProviderSummary(int ukprn, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
I have restored the old endpoint as the new endpoint is not working for rest of the service. Changed the route on the new (existing) endpoint so FAT outer can be refactored to call this one specifically. 