### PR TITLE
CSP 2377 api versioning & swagger generation

### DIFF
--- a/src/SFA.DAS.Roatp.Api/AppStart/ApiVersionHeaderValidationMiddleware.cs
+++ b/src/SFA.DAS.Roatp.Api/AppStart/ApiVersionHeaderValidationMiddleware.cs
@@ -5,8 +5,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Roatp.Api.Infrastructure;
 
-namespace SFA.DAS.Roatp.Api.Infrastructure;
+namespace SFA.DAS.Roatp.Api.AppStart;
 
 [ExcludeFromCodeCoverage]
 public sealed class ApiVersionHeaderValidationMiddleware
@@ -28,7 +29,7 @@ public sealed class ApiVersionHeaderValidationMiddleware
 
         if (!context.Request.Headers.TryGetValue(HeaderName, out var values) || values.Count == 0)
         {
-            await WriteProblem(context, StatusCodes.Status406NotAcceptable,
+            await WriteProblem(context, StatusCodes.Status400BadRequest,
                 "Invalid or missing API version",
                 $"The {HeaderName} header is required. Specify the API version using the '{HeaderName}' header.");
             return;
@@ -36,7 +37,7 @@ public sealed class ApiVersionHeaderValidationMiddleware
 
         if (!double.TryParse(values[0], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var requestedMajor))
         {
-            await WriteProblem(context, StatusCodes.Status406NotAcceptable,
+            await WriteProblem(context, StatusCodes.Status400BadRequest,
                 "Invalid or missing API version",
                 $"The {HeaderName} header value is not a valid API version. Use version, e.g. '1' or '1.0'.");
             return;

--- a/src/SFA.DAS.Roatp.Api/Controllers/CoursesCountController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/CoursesCountController.cs
@@ -12,7 +12,6 @@ namespace SFA.DAS.Roatp.Api.Controllers;
 
 [ApiController]
 [ApiVersion(ApiVersionNumber.One)]
-
 [Route("courses/providers-count")]
 public class CoursesCountController(IMediator _mediator) : ActionResponseControllerBase
 {

--- a/src/SFA.DAS.Roatp.Api/Controllers/CoursesCountController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/CoursesCountController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,8 @@ using SFA.DAS.Roatp.Application.Courses.Queries.GetCourseTrainingProvidersCount;
 namespace SFA.DAS.Roatp.Api.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+
 [Route("courses/providers-count")]
 public class CoursesCountController(IMediator _mediator) : ActionResponseControllerBase
 {

--- a/src/SFA.DAS.Roatp.Api/Controllers/CoursesCountController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/CoursesCountController.cs
@@ -6,11 +6,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Courses.Queries.GetCourseTrainingProvidersCount;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers;
 
 [ApiController]
-[ApiVersion("1.0")]
+[ApiVersion(ApiVersionNumber.One)]
 
 [Route("courses/providers-count")]
 public class CoursesCountController(IMediator _mediator) : ActionResponseControllerBase

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
@@ -23,7 +23,6 @@ public class AcademicYearsController : ControllerBase
     [HttpGet]
     [MapToApiVersion("2.0")]
     [Route("GetV2")]
-    [Route("/providers/{ukprn}")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
@@ -22,6 +22,7 @@ public class AcademicYearsController : ControllerBase
 
     [HttpGet]
     [MapToApiVersion("2.0")]
+    [Route("GetV2")]
     public IActionResult GetV2() => Ok("v2");
 
     [HttpGet]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
@@ -21,6 +21,11 @@ public class AcademicYearsController : ControllerBase
     }
 
     [HttpGet]
+    [MapToApiVersion("2.0")]
+    public IActionResult GetV2() => Ok("v2");
+
+    [HttpGet]
+    [MapToApiVersion("1.0")]
     [Route("latest")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
@@ -26,6 +26,7 @@ public class AcademicYearsController : ControllerBase
 
     [HttpGet]
     [MapToApiVersion("1.0")]
+    [MapToApiVersion("2.0")]
     [Route("latest")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
@@ -4,12 +4,13 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Roatp.Application.AcademicYears.Queries.GetLatest;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers;
 
 [ApiController]
-[ApiVersion("1.0")]
-[ApiVersion("2.0")]
+[ApiVersion(ApiVersionNumber.One)]
+[ApiVersion(ApiVersionNumber.Two)]
 [Route("/api/[controller]/")]
 public class AcademicYearsController : ControllerBase
 {
@@ -21,7 +22,7 @@ public class AcademicYearsController : ControllerBase
     }
 
     [HttpGet]
-    [MapToApiVersion("2.0")]
+    [MapToApiVersion(ApiVersionNumber.Two)]
     [Route("GetV2")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
@@ -29,8 +30,8 @@ public class AcademicYearsController : ControllerBase
     public IActionResult GetV2() => Ok("v2");
 
     [HttpGet]
-    [MapToApiVersion("1.0")]
-    [MapToApiVersion("2.0")]
+    [MapToApiVersion(ApiVersionNumber.One)]
+    [MapToApiVersion(ApiVersionNumber.Two)]
     [Route("latest")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
@@ -23,6 +23,10 @@ public class AcademicYearsController : ControllerBase
     [HttpGet]
     [MapToApiVersion("2.0")]
     [Route("GetV2")]
+    [Route("/providers/{ukprn}")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     public IActionResult GetV2() => Ok("v2");
 
     [HttpGet]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
@@ -1,12 +1,15 @@
-﻿using MediatR;
+﻿using System.Threading.Tasks;
+using Asp.Versioning;
+using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Roatp.Application.AcademicYears.Queries.GetLatest;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[ApiVersion("2.0")]
 [Route("/api/[controller]/")]
 public class AcademicYearsController : ControllerBase
 {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AcademicYearsController.cs
@@ -22,14 +22,6 @@ public class AcademicYearsController : ControllerBase
     }
 
     [HttpGet]
-    [MapToApiVersion(ApiVersionNumber.Two)]
-    [Route("GetV2")]
-    [Produces("application/json")]
-    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-    public IActionResult GetV2() => Ok("v2");
-
-    [HttpGet]
     [MapToApiVersion(ApiVersionNumber.One)]
     [MapToApiVersion(ApiVersionNumber.Two)]
     [Route("latest")]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
@@ -25,6 +25,11 @@ public class AchievementRatesController : ControllerBase
     }
 
     [HttpGet]
+    [MapToApiVersion("2.0")]
+    public IActionResult GetV2() => Ok("v2");
+
+    [HttpGet]
+    [MapToApiVersion("1.0")]
     [Route("Overall")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(List<NationalAchievementRateOverall>), 200)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
@@ -30,6 +30,7 @@ public class AchievementRatesController : ControllerBase
 
     [HttpGet]
     [MapToApiVersion("1.0")]
+    [MapToApiVersion("2.0")]
     [Route("Overall")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(List<NationalAchievementRateOverall>), 200)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Asp.Versioning;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Application.OverallNationalAchievementRates.Queries.GetOverallAchievementRates;
@@ -27,6 +28,9 @@ public class AchievementRatesController : ControllerBase
     [HttpGet]
     [MapToApiVersion("2.0")]
     [Route("GetV2")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     public IActionResult GetV2() => Ok("v2");
 
     [HttpGet]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
@@ -7,12 +7,13 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Application.OverallNationalAchievementRates.Queries.GetOverallAchievementRates;
 using SFA.DAS.Roatp.Domain.Entities;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers;
 
 [ApiController]
-[ApiVersion("1.0")]
-[ApiVersion("2.0")]
+[ApiVersion(ApiVersionNumber.One)]
+[ApiVersion(ApiVersionNumber.Two)]
 [Route("/api/[controller]/")]
 public class AchievementRatesController : ControllerBase
 {
@@ -26,7 +27,7 @@ public class AchievementRatesController : ControllerBase
     }
 
     [HttpGet]
-    [MapToApiVersion("2.0")]
+    [MapToApiVersion(ApiVersionNumber.Two)]
     [Route("GetV2")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
@@ -34,8 +35,8 @@ public class AchievementRatesController : ControllerBase
     public IActionResult GetV2() => Ok("v2");
 
     [HttpGet]
-    [MapToApiVersion("1.0")]
-    [MapToApiVersion("2.0")]
+    [MapToApiVersion(ApiVersionNumber.One)]
+    [MapToApiVersion(ApiVersionNumber.Two)]
     [Route("Overall")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(List<NationalAchievementRateOverall>), 200)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -9,6 +10,8 @@ using SFA.DAS.Roatp.Domain.Entities;
 namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[ApiVersion("2.0")]
 [Route("/api/[controller]/")]
 public class AchievementRatesController : ControllerBase
 {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Asp.Versioning;
 using MediatR;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Application.OverallNationalAchievementRates.Queries.GetOverallAchievementRates;
@@ -25,14 +24,6 @@ public class AchievementRatesController : ControllerBase
         _mediator = mediator;
         _logger = logger;
     }
-
-    [HttpGet]
-    [MapToApiVersion(ApiVersionNumber.Two)]
-    [Route("GetV2")]
-    [Produces("application/json")]
-    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-    public IActionResult GetV2() => Ok("v2");
 
     [HttpGet]
     [MapToApiVersion(ApiVersionNumber.One)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/AchievementRatesController.cs
@@ -26,6 +26,7 @@ public class AchievementRatesController : ControllerBase
 
     [HttpGet]
     [MapToApiVersion("2.0")]
+    [Route("GetV2")]
     public IActionResult GetV2() => Ok("v2");
 
     [HttpGet]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
@@ -25,9 +25,12 @@ public class CoursesController : ActionResponseControllerBase
         _logger = logger;
     }
 
-
+    [HttpGet]
+    [MapToApiVersion("2.0")]
+    public IActionResult GetV2() => Ok("v2");
 
     [HttpGet]
+    [MapToApiVersion("1.0")]
     [Route("{larsCode}/providers")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(GetProvidersForLarsCodeQueryResult), StatusCodes.Status200OK)]
@@ -39,6 +42,7 @@ public class CoursesController : ActionResponseControllerBase
     }
 
     [HttpGet]
+    [MapToApiVersion("1.0")]
     [Route("{larsCode}/providers/{ukprn:int}/details")]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
@@ -28,11 +28,19 @@ public class CoursesController : ActionResponseControllerBase
 
     [HttpGet]
     [MapToApiVersion(ApiVersionNumber.Two)]
-    [Route("GetV2")]
+    [Route("GetVersion")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     public IActionResult GetV2() => Ok("v2");
+
+    [HttpGet]
+    [MapToApiVersion(ApiVersionNumber.One)]
+    [Route("GetVersion")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+    public IActionResult GetV1() => Ok("v1");
 
     [HttpGet]
     [MapToApiVersion(ApiVersionNumber.One)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,8 @@ using SFA.DAS.Roatp.Application.Courses.Queries.GetProvidersFromLarsCode;
 namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[ApiVersion("2.0")]
 [Route("/api/[controller]/")]
 public class CoursesController : ActionResponseControllerBase
 {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
@@ -27,22 +27,6 @@ public class CoursesController : ActionResponseControllerBase
     }
 
     [HttpGet]
-    [MapToApiVersion(ApiVersionNumber.Two)]
-    [Route("GetVersion")]
-    [Produces("application/json")]
-    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-    public IActionResult GetV2() => Ok("v2");
-
-    [HttpGet]
-    [MapToApiVersion(ApiVersionNumber.One)]
-    [Route("GetVersion")]
-    [Produces("application/json")]
-    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-    public IActionResult GetV1() => Ok("v1");
-
-    [HttpGet]
     [MapToApiVersion(ApiVersionNumber.One)]
     [MapToApiVersion(ApiVersionNumber.Two)]
     [Route("{larsCode}/providers")]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
@@ -28,6 +28,9 @@ public class CoursesController : ActionResponseControllerBase
     [HttpGet]
     [MapToApiVersion("2.0")]
     [Route("GetV2")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     public IActionResult GetV2() => Ok("v2");
 
     [HttpGet]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
@@ -31,6 +31,7 @@ public class CoursesController : ActionResponseControllerBase
 
     [HttpGet]
     [MapToApiVersion("1.0")]
+    [MapToApiVersion("2.0")]
     [Route("{larsCode}/providers")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(GetProvidersForLarsCodeQueryResult), StatusCodes.Status200OK)]
@@ -43,6 +44,7 @@ public class CoursesController : ActionResponseControllerBase
 
     [HttpGet]
     [MapToApiVersion("1.0")]
+    [MapToApiVersion("2.0")]
     [Route("{larsCode}/providers/{ukprn:int}/details")]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
@@ -28,7 +28,6 @@ public class CoursesController : ActionResponseControllerBase
 
     [HttpGet]
     [MapToApiVersion(ApiVersionNumber.One)]
-    [MapToApiVersion(ApiVersionNumber.Two)]
     [Route("{larsCode}/providers")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(GetProvidersForLarsCodeQueryResult), StatusCodes.Status200OK)]
@@ -41,7 +40,6 @@ public class CoursesController : ActionResponseControllerBase
 
     [HttpGet]
     [MapToApiVersion(ApiVersionNumber.One)]
-    [MapToApiVersion(ApiVersionNumber.Two)]
     [Route("{larsCode}/providers/{ukprn:int}/details")]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
@@ -27,6 +27,7 @@ public class CoursesController : ActionResponseControllerBase
 
     [HttpGet]
     [MapToApiVersion("2.0")]
+    [Route("GetV2")]
     public IActionResult GetV2() => Ok("v2");
 
     [HttpGet]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/CoursesController.cs
@@ -7,12 +7,13 @@ using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Courses.Queries.GetCourseProviderDetails;
 using SFA.DAS.Roatp.Application.Courses.Queries.GetProvidersFromLarsCode;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers;
 
 [ApiController]
-[ApiVersion("1.0")]
-[ApiVersion("2.0")]
+[ApiVersion(ApiVersionNumber.One)]
+[ApiVersion(ApiVersionNumber.Two)]
 [Route("/api/[controller]/")]
 public class CoursesController : ActionResponseControllerBase
 {
@@ -26,7 +27,7 @@ public class CoursesController : ActionResponseControllerBase
     }
 
     [HttpGet]
-    [MapToApiVersion("2.0")]
+    [MapToApiVersion(ApiVersionNumber.Two)]
     [Route("GetV2")]
     [Produces("application/json")]
     [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
@@ -34,8 +35,8 @@ public class CoursesController : ActionResponseControllerBase
     public IActionResult GetV2() => Ok("v2");
 
     [HttpGet]
-    [MapToApiVersion("1.0")]
-    [MapToApiVersion("2.0")]
+    [MapToApiVersion(ApiVersionNumber.One)]
+    [MapToApiVersion(ApiVersionNumber.Two)]
     [Route("{larsCode}/providers")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(GetProvidersForLarsCodeQueryResult), StatusCodes.Status200OK)]
@@ -47,8 +48,8 @@ public class CoursesController : ActionResponseControllerBase
     }
 
     [HttpGet]
-    [MapToApiVersion("1.0")]
-    [MapToApiVersion("2.0")]
+    [MapToApiVersion(ApiVersionNumber.One)]
+    [MapToApiVersion(ApiVersionNumber.Two)]
     [Route("{larsCode}/providers/{ukprn:int}/details")]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
@@ -83,7 +83,6 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         /// <returns></returns>
         [HttpGet]
         [MapToApiVersion(ApiVersionNumber.One)]
-        [MapToApiVersion(ApiVersionNumber.Two)]
         [Route("{ukprn}/courses")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
@@ -113,7 +112,6 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
 
         [HttpGet]
         [MapToApiVersion(ApiVersionNumber.One)]
-        [MapToApiVersion(ApiVersionNumber.Two)]
         [Route("{ukprn}/courses/{larsCode}")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -19,6 +20,8 @@ using SFA.DAS.Roatp.Domain.Models;
 namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
     [Route("/api/[controller]/")]
     public class ProvidersController : ActionResponseControllerBase
     {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
@@ -40,6 +40,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
 
         [HttpGet]
         [MapToApiVersion("1.0")]
+        [MapToApiVersion("2.0")]
         [Route("")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetProvidersQueryResult), StatusCodes.Status200OK)]
@@ -56,6 +57,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
 
         [HttpGet]
         [MapToApiVersion("1.0")]
+        [MapToApiVersion("2.0")]
         [Route("{ukprn:int}/summary")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetProviderSummaryQueryResult), StatusCodes.Status200OK)]
@@ -68,6 +70,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
 
         [HttpGet]
         [MapToApiVersion("1.0")]
+        [MapToApiVersion("2.0")]
         [Route("{ukprn:int}")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetProviderSummaryQueryResult), StatusCodes.Status200OK)]
@@ -83,6 +86,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         /// <returns></returns>
         [HttpGet]
         [MapToApiVersion("1.0")]
+        [MapToApiVersion("2.0")]
         [Route("{ukprn}/courses")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
@@ -112,6 +116,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
 
         [HttpGet]
         [MapToApiVersion("1.0")]
+        [MapToApiVersion("2.0")]
         [Route("{ukprn}/courses/{larsCode}")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
@@ -16,12 +16,13 @@ using SFA.DAS.Roatp.Application.Providers.Queries.GetProviders;
 using SFA.DAS.Roatp.Application.Providers.Queries.GetProviderSummary;
 using SFA.DAS.Roatp.Application.Providers.Queries.GetRegisteredProvider;
 using SFA.DAS.Roatp.Domain.Models;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
-    [ApiVersion("2.0")]
+    [ApiVersion(ApiVersionNumber.One)]
+    [ApiVersion(ApiVersionNumber.Two)]
     [Route("/api/[controller]/")]
     public class ProvidersController : ActionResponseControllerBase
     {
@@ -35,7 +36,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         }
 
         [HttpGet]
-        [MapToApiVersion("2.0")]
+        [MapToApiVersion(ApiVersionNumber.Two)]
         [Route("GetV2")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
@@ -43,8 +44,8 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         public IActionResult GetV2() => Ok("v2");
 
         [HttpGet]
-        [MapToApiVersion("1.0")]
-        [MapToApiVersion("2.0")]
+        [MapToApiVersion(ApiVersionNumber.One)]
+        [MapToApiVersion(ApiVersionNumber.Two)]
         [Route("")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetProvidersQueryResult), StatusCodes.Status200OK)]
@@ -60,8 +61,8 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         }
 
         [HttpGet]
-        [MapToApiVersion("1.0")]
-        [MapToApiVersion("2.0")]
+        [MapToApiVersion(ApiVersionNumber.One)]
+        [MapToApiVersion(ApiVersionNumber.Two)]
         [Route("{ukprn:int}/summary")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetProviderSummaryQueryResult), StatusCodes.Status200OK)]
@@ -73,8 +74,8 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         }
 
         [HttpGet]
-        [MapToApiVersion("1.0")]
-        [MapToApiVersion("2.0")]
+        [MapToApiVersion(ApiVersionNumber.One)]
+        [MapToApiVersion(ApiVersionNumber.Two)]
         [Route("{ukprn:int}")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetProviderSummaryQueryResult), StatusCodes.Status200OK)]
@@ -89,8 +90,8 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         /// <param name="ukprn"></param>
         /// <returns></returns>
         [HttpGet]
-        [MapToApiVersion("1.0")]
-        [MapToApiVersion("2.0")]
+        [MapToApiVersion(ApiVersionNumber.One)]
+        [MapToApiVersion(ApiVersionNumber.Two)]
         [Route("{ukprn}/courses")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
@@ -119,8 +120,8 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         }
 
         [HttpGet]
-        [MapToApiVersion("1.0")]
-        [MapToApiVersion("2.0")]
+        [MapToApiVersion(ApiVersionNumber.One)]
+        [MapToApiVersion(ApiVersionNumber.Two)]
         [Route("{ukprn}/courses/{larsCode}")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
@@ -36,14 +36,6 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         }
 
         [HttpGet]
-        [MapToApiVersion(ApiVersionNumber.Two)]
-        [Route("GetV2")]
-        [Produces("application/json")]
-        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
-        public IActionResult GetV2() => Ok("v2");
-
-        [HttpGet]
         [MapToApiVersion(ApiVersionNumber.One)]
         [MapToApiVersion(ApiVersionNumber.Two)]
         [Route("")]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
@@ -37,6 +37,9 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         [HttpGet]
         [MapToApiVersion("2.0")]
         [Route("GetV2")]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         public IActionResult GetV2() => Ok("v2");
 
         [HttpGet]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
@@ -35,6 +35,11 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         }
 
         [HttpGet]
+        [MapToApiVersion("2.0")]
+        public IActionResult GetV2() => Ok("v2");
+
+        [HttpGet]
+        [MapToApiVersion("1.0")]
         [Route("")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetProvidersQueryResult), StatusCodes.Status200OK)]
@@ -50,6 +55,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         }
 
         [HttpGet]
+        [MapToApiVersion("1.0")]
         [Route("{ukprn:int}/summary")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetProviderSummaryQueryResult), StatusCodes.Status200OK)]
@@ -61,6 +67,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         }
 
         [HttpGet]
+        [MapToApiVersion("1.0")]
         [Route("{ukprn:int}")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(GetProviderSummaryQueryResult), StatusCodes.Status200OK)]
@@ -75,6 +82,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         /// <param name="ukprn"></param>
         /// <returns></returns>
         [HttpGet]
+        [MapToApiVersion("1.0")]
         [Route("{ukprn}/courses")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
@@ -103,6 +111,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
         }
 
         [HttpGet]
+        [MapToApiVersion("1.0")]
         [Route("{ukprn}/courses/{larsCode}")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ExternalReadControllers/ProvidersController.cs
@@ -36,6 +36,7 @@ namespace SFA.DAS.Roatp.Api.Controllers.ExternalReadControllers
 
         [HttpGet]
         [MapToApiVersion("2.0")]
+        [Route("GetV2")]
         public IActionResult GetV2() => Ok("v2");
 
         [HttpGet]

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderContactController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderContactController.cs
@@ -7,11 +7,12 @@ using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Api.Models;
 using SFA.DAS.Roatp.Application.ProviderContact.Commands.CreateProviderContact;
 using SFA.DAS.Roatp.Application.ProviderContact.Queries.GetProviderContact;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers;
 
 [ApiController]
-[ApiVersion("1.0")]
+[ApiVersion(ApiVersionNumber.One)]
 
 [Route("/providers/{ukprn}/contact")]
 public class ProviderContactController(IMediator _mediator) : ActionResponseControllerBase

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderContactController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderContactController.cs
@@ -13,7 +13,6 @@ namespace SFA.DAS.Roatp.Api.Controllers;
 
 [ApiController]
 [ApiVersion(ApiVersionNumber.One)]
-
 [Route("/providers/{ukprn}/contact")]
 public class ProviderContactController(IMediator _mediator) : ActionResponseControllerBase
 

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderContactController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderContactController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,8 @@ using SFA.DAS.Roatp.Application.ProviderContact.Queries.GetProviderContact;
 namespace SFA.DAS.Roatp.Api.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+
 [Route("/providers/{ukprn}/contact")]
 public class ProviderContactController(IMediator _mediator) : ActionResponseControllerBase
 

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseDeleteController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseDeleteController.cs
@@ -7,11 +7,12 @@ using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Locations.Commands.BulkDelete;
 using SFA.DAS.Roatp.Application.ProviderCourse.Commands.DeleteProviderCourse;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
     public class ProviderCourseDeleteController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderCourseDeleteController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseDeleteController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseDeleteController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,7 @@ using SFA.DAS.Roatp.Application.ProviderCourse.Commands.DeleteProviderCourse;
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
     public class ProviderCourseDeleteController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderCourseDeleteController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseEditController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseEditController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
@@ -12,6 +13,7 @@ using SFA.DAS.Roatp.Domain.Models;
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
     public class ProviderCourseEditController : ActionResponseControllerBase
     {
         private readonly IMediator _mediator;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseEditController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseEditController.cs
@@ -9,11 +9,12 @@ using SFA.DAS.Roatp.Api.Models;
 using SFA.DAS.Roatp.Application.ProviderCourse.Commands.CreateProviderCourse;
 using SFA.DAS.Roatp.Application.ProviderCourse.Commands.PatchProviderCourse;
 using SFA.DAS.Roatp.Domain.Models;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
     public class ProviderCourseEditController : ActionResponseControllerBase
     {
         private readonly IMediator _mediator;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsBulkInsertController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsBulkInsertController.cs
@@ -6,11 +6,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.ProviderCourseLocations.Commands.BulkInsert;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
     public class ProviderCourseLocationsBulkInsertController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderCourseLocationsBulkInsertController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsBulkInsertController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsBulkInsertController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,7 @@ using SFA.DAS.Roatp.Application.ProviderCourseLocations.Commands.BulkInsert;
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
     public class ProviderCourseLocationsBulkInsertController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderCourseLocationsBulkInsertController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsController.cs
@@ -7,11 +7,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.ProviderCourseLocations.Queries.GetProviderCourseLocations;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
     public class ProviderCourseLocationsController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderCourseLocationsController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,7 @@ using SFA.DAS.Roatp.Application.ProviderCourseLocations.Queries.GetProviderCours
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
     public class ProviderCourseLocationsController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderCourseLocationsController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsDeleteController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsDeleteController.cs
@@ -8,11 +8,12 @@ using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.ProviderCourseLocations.Commands.BulkDelete;
 using SFA.DAS.Roatp.Application.ProviderCourseLocations.Commands.Delete;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
     public class ProviderCourseLocationsDeleteController : ActionResponseControllerBase
     {
         private readonly IMediator _mediator;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsDeleteController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsDeleteController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +12,7 @@ using SFA.DAS.Roatp.Application.ProviderCourseLocations.Commands.Delete;
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
     public class ProviderCourseLocationsDeleteController : ActionResponseControllerBase
     {
         private readonly IMediator _mediator;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsEditController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsEditController.cs
@@ -7,11 +7,12 @@ using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Api.Models;
 using SFA.DAS.Roatp.Application.ProviderCourseLocations.Commands.AddNationalLocation;
 using SFA.DAS.Roatp.Application.ProviderCourseLocations.Commands.AddProviderCourseLocation;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
     public class ProviderCourseLocationsEditController : ActionResponseControllerBase
     {
         private readonly IMediator _mediator;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsEditController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseLocationsEditController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -10,6 +11,7 @@ using SFA.DAS.Roatp.Application.ProviderCourseLocations.Commands.AddProviderCour
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
     public class ProviderCourseLocationsEditController : ActionResponseControllerBase
     {
         private readonly IMediator _mediator;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseTypesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseTypesController.cs
@@ -12,7 +12,6 @@ using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 namespace SFA.DAS.Roatp.Api.Controllers;
 
 [ApiVersion(ApiVersionNumber.One)]
-
 [Route("/providers/{ukprn}/course-types", Name = RouteNames.GetProviderCourseTypes)]
 public class ProviderCourseTypesController(IMediator _mediator, ILogger<ProviderCourseLocationsController> _logger) : ActionResponseControllerBase
 {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseTypesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseTypesController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -8,6 +9,8 @@ using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.ProviderCourseTypes.Queries.GetProviderCourseTypes;
 
 namespace SFA.DAS.Roatp.Api.Controllers;
+
+[ApiVersion("1.0")]
 
 [Route("/providers/{ukprn}/course-types", Name = RouteNames.GetProviderCourseTypes)]
 public class ProviderCourseTypesController(IMediator _mediator, ILogger<ProviderCourseLocationsController> _logger) : ActionResponseControllerBase

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseTypesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCourseTypesController.cs
@@ -7,10 +7,11 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.ProviderCourseTypes.Queries.GetProviderCourseTypes;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers;
 
-[ApiVersion("1.0")]
+[ApiVersion(ApiVersionNumber.One)]
 
 [Route("/providers/{ukprn}/course-types", Name = RouteNames.GetProviderCourseTypes)]
 public class ProviderCourseTypesController(IMediator _mediator, ILogger<ProviderCourseLocationsController> _logger) : ActionResponseControllerBase

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCoursesController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +12,8 @@ using SFA.DAS.Roatp.Domain.Models;
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
+
     [Route("[controller]")]
     public class ProviderCoursesController : ActionResponseControllerBase
 

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCoursesController.cs
@@ -14,7 +14,6 @@ namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
     [ApiVersion(ApiVersionNumber.One)]
-
     [Route("[controller]")]
     public class ProviderCoursesController : ActionResponseControllerBase
 

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderCoursesController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderCoursesController.cs
@@ -8,11 +8,12 @@ using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.ProviderCourse.Queries.GetAllProviderCourses;
 using SFA.DAS.Roatp.Application.ProviderCourse.Queries.GetProviderCourse;
 using SFA.DAS.Roatp.Domain.Models;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
 
     [Route("[controller]")]
     public class ProviderCoursesController : ActionResponseControllerBase

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderEditController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderEditController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
@@ -13,6 +14,8 @@ using SFA.DAS.Roatp.Domain.Models;
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
+
     [Route("/providers")]
     public class ProviderEditController : ActionResponseControllerBase
     {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderEditController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderEditController.cs
@@ -16,7 +16,6 @@ namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
     [ApiVersion(ApiVersionNumber.One)]
-
     [Route("/providers")]
     public class ProviderEditController : ActionResponseControllerBase
     {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderEditController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderEditController.cs
@@ -10,11 +10,12 @@ using SFA.DAS.Roatp.Api.Models;
 using SFA.DAS.Roatp.Application.Providers.Commands.CreateProvider;
 using SFA.DAS.Roatp.Application.Providers.Commands.PatchProvider;
 using SFA.DAS.Roatp.Domain.Models;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
 
     [Route("/providers")]
     public class ProviderEditController : ActionResponseControllerBase

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationCreateController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationCreateController.cs
@@ -6,11 +6,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Locations.Commands.CreateLocation;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
 
     public class ProviderLocationCreateController : ActionResponseControllerBase
     {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationCreateController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationCreateController.cs
@@ -1,15 +1,17 @@
-﻿using MediatR;
+﻿using System.Threading.Tasks;
+using Asp.Versioning;
+using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using SFA.DAS.Roatp.Application.Locations.Commands.CreateLocation;
-using System.Threading.Tasks;
 using SFA.DAS.Roatp.Api.Infrastructure;
-using SFA.DAS.Roatp.Application.Common;
+using SFA.DAS.Roatp.Application.Locations.Commands.CreateLocation;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
+
     public class ProviderLocationCreateController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderLocationCreateController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationCreateController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationCreateController.cs
@@ -12,7 +12,6 @@ namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
     [ApiVersion(ApiVersionNumber.One)]
-
     public class ProviderLocationCreateController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderLocationCreateController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationDeleteController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationDeleteController.cs
@@ -7,10 +7,11 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Locations.Commands.DeleteLocation;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers;
 
-[ApiVersion("1.0")]
+[ApiVersion(ApiVersionNumber.One)]
 
 [Route("/providers/{ukprn}/locations/{id}")]
 public class ProviderLocationDeleteController : ActionResponseControllerBase

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationDeleteController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationDeleteController.cs
@@ -12,7 +12,6 @@ using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 namespace SFA.DAS.Roatp.Api.Controllers;
 
 [ApiVersion(ApiVersionNumber.One)]
-
 [Route("/providers/{ukprn}/locations/{id}")]
 public class ProviderLocationDeleteController : ActionResponseControllerBase
 {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationDeleteController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationDeleteController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -8,6 +9,8 @@ using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Locations.Commands.DeleteLocation;
 
 namespace SFA.DAS.Roatp.Api.Controllers;
+
+[ApiVersion("1.0")]
 
 [Route("/providers/{ukprn}/locations/{id}")]
 public class ProviderLocationDeleteController : ActionResponseControllerBase

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationEditController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationEditController.cs
@@ -1,15 +1,18 @@
-﻿using MediatR;
+﻿using System;
+using System.Threading.Tasks;
+using Asp.Versioning;
+using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Api.Models;
 using SFA.DAS.Roatp.Application.Locations.Commands.UpdateProviderLocationDetails;
-using System;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
+
     public class ProviderLocationEditController : ActionResponseControllerBase
     {
         private readonly IMediator _mediator;
@@ -23,10 +26,10 @@ namespace SFA.DAS.Roatp.Api.Controllers
 
         [Route("/providers/{ukprn}/locations/{id}")]
         [HttpPut]
-        public async Task<IActionResult> Save([FromRoute]int ukprn, [FromRoute]Guid id, ProviderLocationEditModel providerLocationEditModel)
+        public async Task<IActionResult> Save([FromRoute] int ukprn, [FromRoute] Guid id, ProviderLocationEditModel providerLocationEditModel)
         {
             _logger.LogInformation("Inner API: Request to update provider location details for ukprn: {ukprn} id: {id} userid:{userid}", ukprn, id, providerLocationEditModel.UserId);
-            var command = (UpdateProviderLocationDetailsCommand) providerLocationEditModel;
+            var command = (UpdateProviderLocationDetailsCommand)providerLocationEditModel;
             command.Ukprn = ukprn;
             command.Id = id;
             var response = await _mediator.Send(command);

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationEditController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationEditController.cs
@@ -13,7 +13,6 @@ namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
     [ApiVersion(ApiVersionNumber.One)]
-
     public class ProviderLocationEditController : ActionResponseControllerBase
     {
         private readonly IMediator _mediator;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationEditController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationEditController.cs
@@ -7,11 +7,12 @@ using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Api.Models;
 using SFA.DAS.Roatp.Application.Locations.Commands.UpdateProviderLocationDetails;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
 
     public class ProviderLocationEditController : ActionResponseControllerBase
     {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkDeleteController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkDeleteController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,8 @@ using SFA.DAS.Roatp.Application.Locations.Commands.BulkDelete;
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
+
     public class ProviderLocationsBulkDeleteController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderLocationsBulkDeleteController> _logger;
@@ -26,7 +29,7 @@ namespace SFA.DAS.Roatp.Api.Controllers
         public async Task<IActionResult> BulkDeleteProviderLocations([FromRoute] int ukprn, [FromQuery] string userId, [FromQuery] string userDisplayName)
         {
             _logger.LogInformation("Inner API: Request received to bulk delete provider locations ukprn: {ukprn}  userid:{userid}", ukprn, userId);
-            
+
             var command = new BulkDeleteProviderLocationsCommand(ukprn, userId, userDisplayName);
             var response = await _mediator.Send(command);
 

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkDeleteController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkDeleteController.cs
@@ -12,7 +12,6 @@ namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
     [ApiVersion(ApiVersionNumber.One)]
-
     public class ProviderLocationsBulkDeleteController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderLocationsBulkDeleteController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkDeleteController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkDeleteController.cs
@@ -6,11 +6,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Locations.Commands.BulkDelete;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
 
     public class ProviderLocationsBulkDeleteController : ActionResponseControllerBase
     {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkInsertController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkInsertController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,8 @@ using SFA.DAS.Roatp.Application.Locations.Commands.BulkInsert;
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
+
     public class ProviderLocationsBulkInsertController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderLocationsBulkInsertController> _logger;
@@ -25,12 +28,12 @@ namespace SFA.DAS.Roatp.Api.Controllers
         [Route("/providers/{ukprn}/locations/bulk-insert-regions")]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(string), StatusCodes.Status204NoContent)]
-        public async Task<IActionResult> BulkInsertProviderLocations([FromRoute] int ukprn,  ProviderLocationsInsertModel providerLocationsInsertModel)
+        public async Task<IActionResult> BulkInsertProviderLocations([FromRoute] int ukprn, ProviderLocationsInsertModel providerLocationsInsertModel)
         {
             _logger.LogInformation("Inner API: Request received to bulk insert locations ukprn: {ukprn} larscode: {larscode} userid:{userid}", ukprn, providerLocationsInsertModel.LarsCode, providerLocationsInsertModel.UserId);
             var command = (BulkInsertProviderLocationsCommand)providerLocationsInsertModel;
             command.Ukprn = ukprn;
-            var response =  await _mediator.Send(command);
+            var response = await _mediator.Send(command);
             if (response.IsValidResponse)
                 _logger.LogInformation("Inserted {numberOfRecordsInserted} provider locations for Ukprn:{ukprn} LarsCode:{larscode}", response.Result, ukprn, providerLocationsInsertModel.LarsCode);
 

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkInsertController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkInsertController.cs
@@ -7,11 +7,12 @@ using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Api.Models;
 using SFA.DAS.Roatp.Application.Locations.Commands.BulkInsert;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
 
     public class ProviderLocationsBulkInsertController : ActionResponseControllerBase
     {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkInsertController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsBulkInsertController.cs
@@ -13,7 +13,6 @@ namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
     [ApiVersion(ApiVersionNumber.One)]
-
     public class ProviderLocationsBulkInsertController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderLocationsBulkInsertController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsController.cs
@@ -1,18 +1,20 @@
-﻿using MediatR;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Asp.Versioning;
+using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Locations.Queries.GetProviderLocationDetails;
 using SFA.DAS.Roatp.Application.Locations.Queries.GetProviderLocations;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
     public class ProviderLocationsController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderLocationsController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProviderLocationsController.cs
@@ -10,11 +10,12 @@ using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Locations.Queries.GetProviderLocationDetails;
 using SFA.DAS.Roatp.Application.Locations.Queries.GetProviderLocations;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
     public class ProviderLocationsController : ActionResponseControllerBase
     {
         private readonly ILogger<ProviderLocationsController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProvidersController.cs
@@ -6,11 +6,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Providers.Queries.GetProvider;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
     public class ProvidersController : ActionResponseControllerBase
     {
         private readonly ILogger<ProvidersController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ProvidersController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ProvidersController.cs
@@ -1,14 +1,16 @@
-﻿using MediatR;
+﻿using System.Threading.Tasks;
+using Asp.Versioning;
+using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Providers.Queries.GetProvider;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
     public class ProvidersController : ActionResponseControllerBase
     {
         private readonly ILogger<ProvidersController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/RegionsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/RegionsController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,8 @@ using SFA.DAS.Roatp.Application.Regions.Queries;
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
+
     public class RegionsController : Controller
     {
         private readonly ILogger<RegionsController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/RegionsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/RegionsController.cs
@@ -6,11 +6,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Roatp.Application.Regions.Queries;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
 
     public class RegionsController : Controller
     {

--- a/src/SFA.DAS.Roatp.Api/Controllers/RegionsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/RegionsController.cs
@@ -12,7 +12,6 @@ namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
     [ApiVersion(ApiVersionNumber.One)]
-
     public class RegionsController : Controller
     {
         private readonly ILogger<RegionsController> _logger;

--- a/src/SFA.DAS.Roatp.Api/Controllers/ShortlistsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ShortlistsController.cs
@@ -14,6 +14,7 @@ using SFA.DAS.Roatp.Application.Shortlists.Commands.DeleteExpiredShortlists;
 using SFA.DAS.Roatp.Application.Shortlists.Commands.DeleteShortlist;
 using SFA.DAS.Roatp.Application.Shortlists.Queries.GetShortlistCountForUser;
 using SFA.DAS.Roatp.Application.Shortlists.Queries.GetShortlistsForUser;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers;
 

--- a/src/SFA.DAS.Roatp.Api/Controllers/ShortlistsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ShortlistsController.cs
@@ -19,9 +19,7 @@ using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 namespace SFA.DAS.Roatp.Api.Controllers;
 
 [ApiController]
-
 [ApiVersion(ApiVersionNumber.One)]
-
 [Route("[controller]")]
 public class ShortlistsController(IMediator _mediator) : ActionResponseControllerBase
 {

--- a/src/SFA.DAS.Roatp.Api/Controllers/ShortlistsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ShortlistsController.cs
@@ -19,7 +19,7 @@ namespace SFA.DAS.Roatp.Api.Controllers;
 
 [ApiController]
 
-[ApiVersion("1.0")]
+[ApiVersion(ApiVersionNumber.One)]
 
 [Route("[controller]")]
 public class ShortlistsController(IMediator _mediator) : ActionResponseControllerBase

--- a/src/SFA.DAS.Roatp.Api/Controllers/ShortlistsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/ShortlistsController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using FluentValidation.Results;
 using MediatR;
 using Microsoft.AspNetCore.Http;
@@ -16,8 +17,11 @@ using SFA.DAS.Roatp.Application.Shortlists.Queries.GetShortlistsForUser;
 
 namespace SFA.DAS.Roatp.Api.Controllers;
 
-[Route("[controller]")]
 [ApiController]
+
+[ApiVersion("1.0")]
+
+[Route("[controller]")]
 public class ShortlistsController(IMediator _mediator) : ActionResponseControllerBase
 {
     [HttpPost]

--- a/src/SFA.DAS.Roatp.Api/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/StandardsController.cs
@@ -14,7 +14,6 @@ namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
     [ApiVersion(ApiVersionNumber.One)]
-
     [Route("/standards")]
     public class StandardsController : ActionResponseControllerBase
     {

--- a/src/SFA.DAS.Roatp.Api/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/StandardsController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +12,8 @@ using SFA.DAS.Roatp.Domain.Models;
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
+    [ApiVersion("1.0")]
+
     [Route("/standards")]
     public class StandardsController : ActionResponseControllerBase
     {

--- a/src/SFA.DAS.Roatp.Api/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.Roatp.Api/Controllers/StandardsController.cs
@@ -8,11 +8,12 @@ using SFA.DAS.Roatp.Api.Infrastructure;
 using SFA.DAS.Roatp.Application.Standards.Queries.GetAllStandards;
 using SFA.DAS.Roatp.Application.Standards.Queries.GetStandardForLarsCode;
 using SFA.DAS.Roatp.Domain.Models;
+using static SFA.DAS.Roatp.Api.Infrastructure.Constants;
 
 namespace SFA.DAS.Roatp.Api.Controllers
 {
     [ApiController]
-    [ApiVersion("1.0")]
+    [ApiVersion(ApiVersionNumber.One)]
 
     [Route("/standards")]
     public class StandardsController : ActionResponseControllerBase

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ApiVersionHeaderValidationMiddleware.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ApiVersionHeaderValidationMiddleware.cs
@@ -1,9 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Asp.Versioning;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -51,28 +49,7 @@ public sealed class ApiVersionHeaderValidationMiddleware
             return;
         }
 
-        var mappedMajors = endpoint.Metadata
-            .OfType<MapToApiVersionAttribute>()
-            .SelectMany(a => a.Versions)
-            .Select(v => v.MajorVersion)
-            .Where(m => m.HasValue)
-            .Select(m => m!.Value)
-            .Distinct()
-            .OrderBy(x => x)
-            .ToArray();
-
-        if (mappedMajors.Length == 0)
-        {
-            mappedMajors = endpoint.Metadata
-                .OfType<ApiVersionAttribute>()
-                .SelectMany(a => a.Versions)
-                .Select(v => v.MajorVersion)
-                .Where(m => m.HasValue)
-                .Select(m => m!.Value)
-                .Distinct()
-                .OrderBy(m => m)
-                .ToArray();
-        }
+        var mappedMajors = ApiVersionMetadata.SupportedAPIVersions(endpoint.Metadata);
 
         if (mappedMajors.Length == 0)
         {

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ApiVersionHeaderValidationMiddleware.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ApiVersionHeaderValidationMiddleware.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace SFA.DAS.Roatp.Api.Infrastructure;
+
+[ExcludeFromCodeCoverage]
+public sealed class ApiVersionHeaderValidationMiddleware
+{
+    private const string HeaderName = "X-Version";
+    private readonly RequestDelegate _next;
+
+    public ApiVersionHeaderValidationMiddleware(RequestDelegate next) => _next = next;
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var path = context.Request.Path;
+
+        if (path.StartsWithSegments("/swagger") && path.Value!.EndsWith("/swagger.json"))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (!context.Request.Headers.TryGetValue(HeaderName, out var values) || values.Count == 0)
+        {
+            await WriteProblem(context, StatusCodes.Status400BadRequest,
+                "Invalid or missing API version",
+                $"The {HeaderName} header is required. Specify the API version using the '{HeaderName}' header.");
+            return;
+        }
+
+        if (!double.TryParse(values[0], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var requestedMajor))
+        {
+            await WriteProblem(context, StatusCodes.Status400BadRequest,
+                "Invalid or missing API version",
+                $"The {HeaderName} header value is not a valid API version. Use version, e.g. '1' or '1.0'.");
+            return;
+        }
+
+        var endpoint = context.GetEndpoint();
+        if (endpoint is null)
+        {
+            await _next(context);
+            return;
+        }
+
+        var mappedMajors = endpoint.Metadata
+            .OfType<MapToApiVersionAttribute>()
+            .SelectMany(a => a.Versions)
+            .Select(v => v.MajorVersion)
+            .Where(m => m.HasValue)
+            .Select(m => m!.Value)
+            .Distinct()
+            .OrderBy(x => x)
+            .ToArray();
+
+        if (mappedMajors.Length == 0)
+        {
+            await WriteProblem(context, StatusCodes.Status400BadRequest,
+                "Unsupported API version",
+                $"The requested API version '{requestedMajor.ToString("0.0", CultureInfo.InvariantCulture)}' is not supported.");
+            return;
+        }
+
+        await _next(context);
+    }
+
+    private static async Task WriteProblem(HttpContext context, int status, string title, string detail)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = status,
+            Title = title,
+            Detail = detail,
+            Type = $"https://httpstatuses.com/{status}"
+        };
+
+        context.Response.StatusCode = status;
+        context.Response.ContentType = "application/problem+json";
+        var json = JsonSerializer.Serialize(problem);
+        await context.Response.WriteAsync(json);
+    }
+}
+
+public static class ApiVersionHeaderValidationMiddlewareExtensions
+{
+    public static IApplicationBuilder UseApiVersionHeaderValidation(this IApplicationBuilder app) =>
+        app.UseMiddleware<ApiVersionHeaderValidationMiddleware>();
+}

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ApiVersionHeaderValidationMiddleware.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ApiVersionHeaderValidationMiddleware.cs
@@ -28,7 +28,7 @@ public sealed class ApiVersionHeaderValidationMiddleware
 
         if (!context.Request.Headers.TryGetValue(HeaderName, out var values) || values.Count == 0)
         {
-            await WriteProblem(context, StatusCodes.Status400BadRequest,
+            await WriteProblem(context, StatusCodes.Status406NotAcceptable,
                 "Invalid or missing API version",
                 $"The {HeaderName} header is required. Specify the API version using the '{HeaderName}' header.");
             return;
@@ -36,7 +36,7 @@ public sealed class ApiVersionHeaderValidationMiddleware
 
         if (!double.TryParse(values[0], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var requestedMajor))
         {
-            await WriteProblem(context, StatusCodes.Status400BadRequest,
+            await WriteProblem(context, StatusCodes.Status406NotAcceptable,
                 "Invalid or missing API version",
                 $"The {HeaderName} header value is not a valid API version. Use version, e.g. '1' or '1.0'.");
             return;
@@ -53,7 +53,7 @@ public sealed class ApiVersionHeaderValidationMiddleware
 
         if (mappedMajors.Length == 0)
         {
-            await WriteProblem(context, StatusCodes.Status400BadRequest,
+            await WriteProblem(context, StatusCodes.Status406NotAcceptable,
                 "Unsupported API version",
                 $"The requested API version '{requestedMajor.ToString("0.0", CultureInfo.InvariantCulture)}' is not supported.");
             return;

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ApiVersionMetadata.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ApiVersionMetadata.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Linq;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+
+namespace SFA.DAS.Roatp.Api.Infrastructure;
+
+public static class ApiVersionMetadata
+{
+    public static int[] SupportedAPIVersions(EndpointMetadataCollection metadata)
+    {
+        var mappedMajors = metadata
+            .OfType<MapToApiVersionAttribute>()
+            .SelectMany(a => a.Versions)
+            .Select(v => v.MajorVersion)
+            .Where(m => m.HasValue)
+            .Select(m => m!.Value)
+            .Distinct()
+            .ToArray();
+
+        if (mappedMajors.Length == 0)
+        {
+            mappedMajors = metadata
+                .OfType<ApiVersionAttribute>()
+                .SelectMany(a => a.Versions)
+                .Select(v => v.MajorVersion)
+                .Where(m => m.HasValue)
+                .Select(m => m!.Value)
+                .Distinct()
+                .ToArray();
+        }
+
+        return mappedMajors;
+    }
+
+    public static int[] SupportedAPIVersions(IList<object> endpointMetadata)
+    {
+        var mappedMajors = endpointMetadata
+            .OfType<MapToApiVersionAttribute>()
+            .SelectMany(a => a.Versions)
+            .Select(v => v.MajorVersion)
+            .Where(m => m.HasValue)
+            .Select(m => m!.Value)
+            .Distinct()
+            .ToArray();
+
+        if (mappedMajors.Length == 0)
+        {
+            mappedMajors = endpointMetadata
+                .OfType<ApiVersionAttribute>()
+                .SelectMany(a => a.Versions)
+                .Select(v => v.MajorVersion)
+                .Where(m => m.HasValue)
+                .Select(m => m!.Value)
+                .Distinct()
+                .ToArray();
+        }
+
+        return mappedMajors;
+    }
+}

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerGenOptions.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerGenOptions.cs
@@ -8,11 +8,11 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace SFA.DAS.Roatp.Api.Infrastructure;
 
-public class ConfigureSwaggerOptions : IConfigureOptions<SwaggerGenOptions>
+public class ConfigureSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
 {
     private readonly IApiVersionDescriptionProvider _provider;
 
-    public ConfigureSwaggerOptions(IApiVersionDescriptionProvider provider)
+    public ConfigureSwaggerGenOptions(IApiVersionDescriptionProvider provider)
     {
         _provider = provider ?? throw new ArgumentNullException(nameof(provider));
     }
@@ -31,12 +31,6 @@ public class ConfigureSwaggerOptions : IConfigureOptions<SwaggerGenOptions>
                 Version = apiVersionDescription.ApiVersion.ToString()
             });
         }
-
-        // Include ApiDescriptions where ApiExplorer GroupName equals the swagger doc name
-        options.DocInclusionPredicate((docName, apiDesc) =>
-        {
-            return string.Equals(apiDesc.GroupName, docName, StringComparison.OrdinalIgnoreCase);
-        });
 
         options.OperationFilter<SwaggerHeaderFilter>();
     }

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerGenOptions.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerGenOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Asp.Versioning.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,6 +9,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace SFA.DAS.Roatp.Api.Infrastructure;
 
+[ExcludeFromCodeCoverage]
 public class ConfigureSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
 {
     private readonly IApiVersionDescriptionProvider _provider;

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerGenOptions.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerGenOptions.cs
@@ -32,6 +32,15 @@ public class ConfigureSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
             });
         }
 
+        // Include actions based on ApiExplorer.GroupName ("Integration"/"Management")
+        // Match docs with suffix "V{major}" by comparing the prefix to apiDesc.GroupName
+        options.DocInclusionPredicate((docName, apiDesc) =>
+        {
+            var dashIndex = docName.IndexOf('V');
+            var groupPrefix = dashIndex > 0 ? docName[..dashIndex] : docName;
+            return string.Equals(apiDesc.GroupName, groupPrefix, StringComparison.OrdinalIgnoreCase);
+        });
+
         options.OperationFilter<SwaggerHeaderFilter>();
     }
 }

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerGenOptions.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerGenOptions.cs
@@ -36,7 +36,6 @@ public class ConfigureSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
 
         DocInclusionPredicate(options);
 
-        AddOpenIdSecurityRequirement(options);
         AddBearerSecurityRequirement(options);
 
         options.OperationFilter<SwaggerHeaderFilter>();
@@ -65,37 +64,6 @@ public class ConfigureSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
             if (mappedMajors.Length == 0) return false;
 
             return mappedMajors.Contains(major);
-        });
-    }
-
-    private static void AddOpenIdSecurityRequirement(SwaggerGenOptions options)
-    {
-        // OpenID Connect discovery endpoint (replace with your tenant authority if needed)
-        // Example for Microsoft Entra ID tenant: https://login.microsoftonline.com/{tenantId}/v2.0
-        var discoveryUrl = new Uri("https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration");
-
-        var openIdScheme = new OpenApiSecurityScheme
-        {
-            Type = SecuritySchemeType.OpenIdConnect,
-            OpenIdConnectUrl = discoveryUrl,
-            Description = "Interactive login as user",
-            Name = "Auhorization",
-            In = ParameterLocation.Header,
-            Reference = new OpenApiReference
-            {
-                Type = ReferenceType.SecurityScheme,
-                Id = "OpenIdConnect"
-            }
-        };
-
-        options.AddSecurityDefinition("OpenIdConnect", openIdScheme);
-
-        options.AddSecurityRequirement(new OpenApiSecurityRequirement
-        {
-            {
-                openIdScheme,
-                Array.Empty<string>()
-            }
         });
     }
 

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerGenOptions.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerGenOptions.cs
@@ -23,7 +23,7 @@ public class ConfigureSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
     {
         options.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
 
-        foreach (var apiVersionDescription in _provider.ApiVersionDescriptions)
+        foreach (var apiVersionDescription in _provider.ApiVersionDescriptions.OrderBy(d => d.GroupName))
         {
             var docName = $"{apiVersionDescription.GroupName}V{apiVersionDescription.ApiVersion.MajorVersion}";
 

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerOptions.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerOptions.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using Asp.Versioning.ApiExplorer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace SFA.DAS.Roatp.Api.Infrastructure;
+
+public class ConfigureSwaggerOptions : IConfigureOptions<SwaggerGenOptions>
+{
+    private readonly IApiVersionDescriptionProvider _provider;
+
+    public ConfigureSwaggerOptions(IApiVersionDescriptionProvider provider)
+    {
+        _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+    }
+
+    public void Configure(SwaggerGenOptions options)
+    {
+        options.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
+
+        foreach (var apiVersionDescription in _provider.ApiVersionDescriptions)
+        {
+            var docName = $"{apiVersionDescription.GroupName}V{apiVersionDescription.ApiVersion.MajorVersion}";
+
+            options.SwaggerDoc(docName, new OpenApiInfo
+            {
+                Title = $"{apiVersionDescription.GroupName} V{apiVersionDescription.ApiVersion.MajorVersion}",
+                Version = apiVersionDescription.ApiVersion.ToString()
+            });
+        }
+
+        // Include ApiDescriptions where ApiExplorer GroupName equals the swagger doc name
+        options.DocInclusionPredicate((docName, apiDesc) =>
+        {
+            return string.Equals(apiDesc.GroupName, docName, StringComparison.OrdinalIgnoreCase);
+        });
+
+        options.OperationFilter<SwaggerHeaderFilter>();
+    }
+}

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerUiOptions.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerUiOptions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using Asp.Versioning.ApiExplorer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Options;
+using Swashbuckle.AspNetCore.SwaggerUI;
+
+namespace SFA.DAS.Roatp.Api.AppStart;
+
+public sealed class ConfigureSwaggerUiOptions : IConfigureOptions<SwaggerUIOptions>
+{
+    private readonly IApiVersionDescriptionProvider _provider;
+
+    public ConfigureSwaggerUiOptions(IApiVersionDescriptionProvider provider)
+    {
+        _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+    }
+
+    public void Configure(SwaggerUIOptions options)
+    {
+        foreach (var description in _provider.ApiVersionDescriptions
+                      .OrderBy(d => d.GroupName, StringComparer.OrdinalIgnoreCase)
+                      .ThenByDescending(d => d.ApiVersion))
+        {
+            var docName = $"{description.GroupName}V{description.ApiVersion.MajorVersion}";
+            options.SwaggerEndpoint($"/swagger/{docName}/swagger.json", $"{description.GroupName} V{description.ApiVersion.MajorVersion}");
+        }
+        options.RoutePrefix = string.Empty;
+    }
+}

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerUiOptions.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerUiOptions.cs
@@ -20,9 +20,7 @@ public sealed class ConfigureSwaggerUiOptions : IConfigureOptions<SwaggerUIOptio
 
     public void Configure(SwaggerUIOptions options)
     {
-        foreach (var description in _provider.ApiVersionDescriptions
-                      .OrderBy(d => d.GroupName, StringComparer.OrdinalIgnoreCase)
-                      .ThenByDescending(d => d.ApiVersion))
+        foreach (var description in _provider.ApiVersionDescriptions.OrderBy(d => d.GroupName))
         {
             var docName = $"{description.GroupName}V{description.ApiVersion.MajorVersion}";
             options.SwaggerEndpoint($"/swagger/{docName}/swagger.json", $"{description.GroupName} V{description.ApiVersion.MajorVersion}");

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerUiOptions.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/ConfigureSwaggerUiOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Asp.Versioning.ApiExplorer;
 using Microsoft.AspNetCore.Builder;
@@ -7,6 +8,7 @@ using Swashbuckle.AspNetCore.SwaggerUI;
 
 namespace SFA.DAS.Roatp.Api.AppStart;
 
+[ExcludeFromCodeCoverage]
 public sealed class ConfigureSwaggerUiOptions : IConfigureOptions<SwaggerUIOptions>
 {
     private readonly IApiVersionDescriptionProvider _provider;

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/Constants.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/Constants.cs
@@ -10,4 +10,10 @@ public static class Constants
         public const string Integration = nameof(Integration);
         public const string Management = nameof(Management);
     }
+
+    public static class ApiVersionNumber
+    {
+        public const string One = "1.0";
+        public const string Two = "2.0";
+    }
 }

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/SwaggerHeaderFilter.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/SwaggerHeaderFilter.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.OpenApi.Any;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace SFA.DAS.Roatp.Api.Infrastructure;
 

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/SwaggerHeaderFilter.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/SwaggerHeaderFilter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Asp.Versioning;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -22,28 +21,7 @@ public class SwaggerHeaderFilter : IOperationFilter
 
         var endpointMetadata = context.ApiDescription.ActionDescriptor.EndpointMetadata;
 
-        var mappedMajors = endpointMetadata
-            .OfType<MapToApiVersionAttribute>()
-            .SelectMany(a => a.Versions)
-            .Select(v => v.MajorVersion)
-            .Where(m => m.HasValue)
-            .Select(m => m!.Value)
-            .Distinct()
-            .OrderBy(m => m)
-            .ToArray();
-
-        if (mappedMajors.Length == 0)
-        {
-            mappedMajors = endpointMetadata
-                .OfType<ApiVersionAttribute>()
-                .SelectMany(a => a.Versions)
-                .Select(v => v.MajorVersion)
-                .Where(m => m.HasValue)
-                .Select(m => m!.Value)
-                .Distinct()
-                .OrderBy(m => m)
-                .ToArray();
-        }
+        var mappedMajors = ApiVersionMetadata.SupportedAPIVersions(endpointMetadata);
 
         var defaultMajor = mappedMajors.Length > 0 ? mappedMajors.First() : 1;
         var defaultValue = $"{defaultMajor}.0";

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/SwaggerHeaderFilter.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/SwaggerHeaderFilter.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.OpenApi.Any;
+using System.Linq;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -9,17 +10,28 @@ namespace SFA.DAS.Roatp.Api.Infrastructure;
 [ExcludeFromCodeCoverage]
 public class SwaggerHeaderFilter : IOperationFilter
 {
+    private const string VersionHeaderName = "X-Version";
+
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
+        if (operation == null) throw new ArgumentNullException(nameof(operation));
+
         operation.Parameters ??= new List<OpenApiParameter>();
 
-        operation.Parameters.Add(new OpenApiParameter
+        // Do not add if a header parameter with the same name already exists.
+        var alreadyHas = operation.Parameters
+            .Any(p => string.Equals(p.Name, VersionHeaderName, StringComparison.OrdinalIgnoreCase)
+                      && p.In == ParameterLocation.Header);
+
+        if (alreadyHas) return;
+
+        operation.Parameters.Insert(0, new OpenApiParameter
         {
-            Name = "X-Version",
+            Name = VersionHeaderName,
             In = ParameterLocation.Header,
-            AllowEmptyValue = false,
-            Example = new OpenApiString("1.0"),
-            Required = true
+            Description = "API version (header)",
+            Required = false,
+            Schema = new OpenApiSchema { Type = "string" }
         });
     }
 }

--- a/src/SFA.DAS.Roatp.Api/Infrastructure/SwaggerHeaderFilter.cs
+++ b/src/SFA.DAS.Roatp.Api/Infrastructure/SwaggerHeaderFilter.cs
@@ -20,7 +20,6 @@ public class SwaggerHeaderFilter : IOperationFilter
 
         operation.Parameters ??= new List<OpenApiParameter>();
 
-        // Discover supported major versions from endpoint metadata
         var endpointMetadata = context.ApiDescription.ActionDescriptor.EndpointMetadata;
 
         var mappedMajors = endpointMetadata
@@ -46,18 +45,15 @@ public class SwaggerHeaderFilter : IOperationFilter
                 .ToArray();
         }
 
-        // Choose a default: first supported major (or fallback to 1 if nothing discovered)
         var defaultMajor = mappedMajors.Length > 0 ? mappedMajors.First() : 1;
         var defaultValue = $"{defaultMajor}.0";
 
-        // Find existing header parameter if present
         var existing = operation.Parameters
             .FirstOrDefault(p => string.Equals(p.Name, VersionHeaderName, StringComparison.OrdinalIgnoreCase)
                                  && p.In == ParameterLocation.Header);
 
         if (existing is null)
         {
-            // Insert new parameter
             operation.Parameters.Insert(0, new OpenApiParameter
             {
                 Name = VersionHeaderName,
@@ -74,7 +70,6 @@ public class SwaggerHeaderFilter : IOperationFilter
         }
         else
         {
-            // Update existing parameter without re-adding
             existing.Description = $"Example: {defaultValue}";
             existing.Required = false;
 

--- a/src/SFA.DAS.Roatp.Api/SFA.DAS.Roatp.Api.csproj
+++ b/src/SFA.DAS.Roatp.Api/SFA.DAS.Roatp.Api.csproj
@@ -5,15 +5,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11" />
-    <PackageReference Include="SFA.DAS.Api.Common" Version="17.1.135" />
-    <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="17.1.138" />
-    <PackageReference Include="SFA.DAS.Telemetry" Version="17.1.95" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.3" />
+	  <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />
+	  <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+	  <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
+	  <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.11" />
+	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
+	  <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11" />
+	  <PackageReference Include="SFA.DAS.Api.Common" Version="17.1.135" />
+	  <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="17.1.138" />
+	  <PackageReference Include="SFA.DAS.Telemetry" Version="17.1.95" />
+	  <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
+	  <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SFA.DAS.Roatp.Application\SFA.DAS.Roatp.Application.csproj" />

--- a/src/SFA.DAS.Roatp.Api/Startup.cs
+++ b/src/SFA.DAS.Roatp.Api/Startup.cs
@@ -125,12 +125,11 @@ public class Startup
 
             foreach (var apiVersionDescription in provider.ApiVersionDescriptions)
             {
-                // Make the doc name unique by appending the ApiVersion
-                var docName = $"{apiVersionDescription.GroupName}-{apiVersionDescription.ApiVersion}";
+                var docName = $"{apiVersionDescription.GroupName}V{apiVersionDescription.ApiVersion.MajorVersion}";
 
                 options.SwaggerDoc(docName, new OpenApiInfo
                 {
-                    Title = $"{apiVersionDescription.GroupName} v{apiVersionDescription.ApiVersion}",
+                    Title = $"{apiVersionDescription.GroupName} V{apiVersionDescription.ApiVersion.MajorVersion}",
                     Version = apiVersionDescription.ApiVersion.ToString()
                 });
             }
@@ -142,16 +141,6 @@ public class Startup
     // Non-static so the ApiVersionDescriptionProvider can be injected
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IApiVersionDescriptionProvider provider)
     {
-        var logger = app.ApplicationServices.GetRequiredService<ILogger<Startup>>();
-
-        // Log what ApiExplorer reports
-        logger.LogInformation("ApiVersionDescriptions count: {Count}", provider.ApiVersionDescriptions.Count());
-        foreach (var d in provider.ApiVersionDescriptions)
-        {
-            logger.LogInformation("ApiVersionDescription: GroupName={GroupName}, ApiVersion={ApiVersion}, IsDeprecated={IsDeprecated}",
-                d.GroupName, d.ApiVersion, d.IsDeprecated);
-        }
-
         if (env.IsDevelopment())
         {
             app.UseDeveloperExceptionPage();
@@ -163,15 +152,14 @@ public class Startup
 
         app.UseSwaggerUI(options =>
         {
-            // Register an endpoint for every ApiVersionDescription using the ApiExplorer GroupName.
             var ordered = provider.ApiVersionDescriptions
                 .OrderBy(d => d.GroupName, StringComparer.OrdinalIgnoreCase)
                 .ThenByDescending(d => d.ApiVersion);
 
             foreach (var description in ordered)
             {
-                var docName = $"{description.GroupName}-{description.ApiVersion}";
-                options.SwaggerEndpoint($"/swagger/{docName}/swagger.json", $"{description.GroupName} v{description.ApiVersion}");
+                var docName = $"{description.GroupName}V{description.ApiVersion.MajorVersion}";
+                options.SwaggerEndpoint($"/swagger/{docName}/swagger.json", $"{description.GroupName} V{description.ApiVersion.MajorVersion}");
             }
 
             options.RoutePrefix = string.Empty;

--- a/src/SFA.DAS.Roatp.Api/Startup.cs
+++ b/src/SFA.DAS.Roatp.Api/Startup.cs
@@ -105,7 +105,7 @@ public class Startup
             {
                 if (!IsEnvironmentLocalOrDev)
                     o.Conventions.Add(new AuthorizeByPathControllerModelConvention());
-                //o.Conventions.Add(new ApiExplorerGroupingConvention());
+                o.Conventions.Add(new ApiExplorerGroupingConvention());
             })
             .AddJsonOptions(options =>
             {

--- a/src/SFA.DAS.Roatp.Api/Startup.cs
+++ b/src/SFA.DAS.Roatp.Api/Startup.cs
@@ -89,11 +89,12 @@ public class Startup
         services.AddApiVersioning(opt =>
         {
 
+
             opt.ApiVersionReader = new HeaderApiVersionReader("X-Version");
             opt.AssumeDefaultVersionWhenUnspecified = false; // prevent blanket default
             opt.ReportApiVersions = true;
-
-        }).AddApiExplorer(options =>
+        })
+        .AddApiExplorer(options =>
         {
             options.GroupNameFormat = "'v'VVV";
             options.SubstituteApiVersionInUrl = true;
@@ -148,6 +149,9 @@ public class Startup
         app.UseApiVersionHeaderValidation();
 
         app.UseHealthChecks();
+
+        if (env.IsDevelopment())
+            app.UseAuthorization();
 
         app.UseEndpoints(endpoints =>
         {

--- a/src/SFA.DAS.Roatp.Api/Startup.cs
+++ b/src/SFA.DAS.Roatp.Api/Startup.cs
@@ -139,12 +139,13 @@ public class Startup
         app.UseAuthentication();
 
         app.UseSwagger();
-
         app.UseSwaggerUI();
 
         app.UseHttpsRedirection();
 
         app.UseRouting();
+
+        app.UseApiVersionHeaderValidation();
 
         app.UseHealthChecks();
 

--- a/src/SFA.DAS.Roatp.Api/Startup.cs
+++ b/src/SFA.DAS.Roatp.Api/Startup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text.Json.Serialization;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Builder;
@@ -91,7 +90,7 @@ public class Startup
 
 
             opt.ApiVersionReader = new HeaderApiVersionReader("X-Version");
-            opt.AssumeDefaultVersionWhenUnspecified = false; // prevent blanket default
+            opt.AssumeDefaultVersionWhenUnspecified = false;
             opt.ReportApiVersions = true;
         })
         .AddApiExplorer(options =>
@@ -121,8 +120,6 @@ public class Startup
 
         services.AddSwaggerGen(options =>
         {
-            options.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
-
             options.OperationFilter<SwaggerHeaderFilter>();
         });
 

--- a/src/SFA.DAS.Roatp.Api/Startup.cs
+++ b/src/SFA.DAS.Roatp.Api/Startup.cs
@@ -150,7 +150,7 @@ public class Startup
 
         app.UseHealthChecks();
 
-        if (env.IsDevelopment())
+        if (!env.IsDevelopment())
             app.UseAuthorization();
 
         app.UseEndpoints(endpoints =>

--- a/src/SFA.DAS.Roatp.Jobs/Extensions/AddApplicationRegistrationsExtension.cs
+++ b/src/SFA.DAS.Roatp.Jobs/Extensions/AddApplicationRegistrationsExtension.cs
@@ -5,6 +5,7 @@ using SFA.DAS.Roatp.Jobs.Configuration;
 using SFA.DAS.Roatp.Jobs.Services;
 
 namespace SFA.DAS.Roatp.Jobs.Extensions;
+
 public static class AddApplicationRegistrationsExtension
 {
     public static IServiceCollection AddServiceRegistrations(this IServiceCollection services, IConfiguration configuration)

--- a/src/SFA.DAS.Roatp.Jobs/Extensions/AddApplicationRegistrationsExtension.cs
+++ b/src/SFA.DAS.Roatp.Jobs/Extensions/AddApplicationRegistrationsExtension.cs
@@ -5,7 +5,6 @@ using SFA.DAS.Roatp.Jobs.Configuration;
 using SFA.DAS.Roatp.Jobs.Services;
 
 namespace SFA.DAS.Roatp.Jobs.Extensions;
-
 public static class AddApplicationRegistrationsExtension
 {
     public static IServiceCollection AddServiceRegistrations(this IServiceCollection services, IConfiguration configuration)


### PR DESCRIPTION
This pull request adds API versioning support to all controller classes in the project. The changes introduce the use of the `Asp.Versioning` library, apply version attributes to controllers and endpoints, and update routing and response metadata to support multiple API versions (primarily v1 and v2). 
