### PR TITLE
CSP-2445 drop column learning type

### DIFF
--- a/src/SFA.DAS.Roatp.Api.UnitTests/Controllers/ExternalReadControllers/ProvidersControllerTests.cs
+++ b/src/SFA.DAS.Roatp.Api.UnitTests/Controllers/ExternalReadControllers/ProvidersControllerTests.cs
@@ -251,7 +251,7 @@ public class ProvidersControllerTests
         {
             ProviderCourseId = 2,
             LarsCode = "999",
-            CourseType = CourseType.ApprenticeshipUnit
+            CourseType = CourseType.ShortCourse
         };
 
         var handlerResult = new List<ProviderCourseModel> { apprenticeship, shortCourse };

--- a/src/SFA.DAS.Roatp.Application.UnitTests/Common/CourseTypeValidatorTests.cs
+++ b/src/SFA.DAS.Roatp.Application.UnitTests/Common/CourseTypeValidatorTests.cs
@@ -69,7 +69,7 @@ public class CourseTypeValidatorTests
         _providerCourseTypesReadRepositoryMock.Setup(r => r.GetProviderCourseTypesByUkprn(It.IsAny<int>()))
             .ReturnsAsync(new List<ProviderCourseType>
             {
-                new ProviderCourseType { CourseType = CourseType.ApprenticeshipUnit }
+                new ProviderCourseType { CourseType = CourseType.ShortCourse }
             });
 
         _sut = new CourseTypeValidator(_providerCourseTypesReadRepositoryMock.Object, _standardsReadRepositoryMock.Object);
@@ -91,7 +91,7 @@ public class CourseTypeValidatorTests
             .ReturnsAsync(new List<ProviderCourseType>
             {
                 new ProviderCourseType { CourseType = CourseType.Apprenticeship },
-                new ProviderCourseType { CourseType = CourseType.ApprenticeshipUnit }
+                new ProviderCourseType { CourseType = CourseType.ShortCourse }
             });
 
         _sut = new CourseTypeValidator(_providerCourseTypesReadRepositoryMock.Object, _standardsReadRepositoryMock.Object);

--- a/src/SFA.DAS.Roatp.Application.UnitTests/ProviderCourse/Queries/ProviderAllCoursesQueryHandlerTests.cs
+++ b/src/SFA.DAS.Roatp.Application.UnitTests/ProviderCourse/Queries/ProviderAllCoursesQueryHandlerTests.cs
@@ -188,7 +188,7 @@ public class ProviderAllCoursesQueryHandlerTests
         var courses = new List<Domain.Entities.ProviderCourse>
         {
             new() { ProviderId = 1, IsApprovedByRegulator = true, Standard = new Standard { IsRegulatedForProvider = false, CourseType = CourseType.Apprenticeship }, LarsCode = larsCodeOne},
-            new() { ProviderId = 1, IsApprovedByRegulator = true, Standard = new Standard { IsRegulatedForProvider = false, CourseType = CourseType.ApprenticeshipUnit }, LarsCode = larsCodeTwo}
+            new() { ProviderId = 1, IsApprovedByRegulator = true, Standard = new Standard { IsRegulatedForProvider = false, CourseType = CourseType.ShortCourse }, LarsCode = larsCodeTwo}
         };
 
         providersReadRepositoryMock.Setup(r => r.GetAllProviderCourses(query.Ukprn)).ReturnsAsync(courses);
@@ -212,14 +212,14 @@ public class ProviderAllCoursesQueryHandlerTests
         var larsCodeOne = "1";
         var larsCodeTwo = "2";
 
-        var expectedCourseType = CourseType.ApprenticeshipUnit;
+        var expectedCourseType = CourseType.ShortCourse;
 
         var query = new GetAllProviderCoursesQuery(1, false, expectedCourseType);
 
         var courses = new List<Domain.Entities.ProviderCourse>
         {
             new() { ProviderId = 1, IsApprovedByRegulator = true, Standard = new Standard { IsRegulatedForProvider = false, CourseType = CourseType.Apprenticeship }, LarsCode = larsCodeOne},
-            new() { ProviderId = 1, IsApprovedByRegulator = true, Standard = new Standard { IsRegulatedForProvider = false, CourseType = CourseType.ApprenticeshipUnit }, LarsCode = larsCodeTwo}
+            new() { ProviderId = 1, IsApprovedByRegulator = true, Standard = new Standard { IsRegulatedForProvider = false, CourseType = CourseType.ShortCourse }, LarsCode = larsCodeTwo}
         };
 
         providersReadRepositoryMock.Setup(r => r.GetAllProviderCourses(query.Ukprn)).ReturnsAsync(courses);
@@ -246,7 +246,7 @@ public class ProviderAllCoursesQueryHandlerTests
         var courses = new List<Domain.Entities.ProviderCourse>
         {
             new() { ProviderId = ukprn, IsApprovedByRegulator = true, Standard = new Standard { IsRegulatedForProvider = false, CourseType = CourseType.Apprenticeship }, LarsCode = "1" },
-            new() { ProviderId = ukprn, IsApprovedByRegulator = true, Standard = new Standard { IsRegulatedForProvider = false, CourseType = CourseType.ApprenticeshipUnit }, LarsCode = "2" }
+            new() { ProviderId = ukprn, IsApprovedByRegulator = true, Standard = new Standard { IsRegulatedForProvider = false, CourseType = CourseType.ShortCourse }, LarsCode = "2" }
         };
 
         providersReadRepositoryMock.Setup(r => r.GetAllProviderCourses(ukprn)).ReturnsAsync(courses);
@@ -258,6 +258,6 @@ public class ProviderAllCoursesQueryHandlerTests
         response.Should().NotBeNull();
         response.Result.Should().HaveCount(2);
         response.Result.Should().ContainSingle(r => r.CourseType == CourseType.Apprenticeship);
-        response.Result.Should().ContainSingle(r => r.CourseType == CourseType.ApprenticeshipUnit);
+        response.Result.Should().ContainSingle(r => r.CourseType == CourseType.ShortCourse);
     }
 }

--- a/src/SFA.DAS.Roatp.Application.UnitTests/ProviderCourse/Queries/ProviderCourseQueryValidatorTests.cs
+++ b/src/SFA.DAS.Roatp.Application.UnitTests/ProviderCourse/Queries/ProviderCourseQueryValidatorTests.cs
@@ -98,7 +98,7 @@ public class ProviderCourseQueryValidatorTests
             .ReturnsAsync(new Standard { CourseType = CourseType.Apprenticeship });
 
         _providerCourseTypesReadRepositoryMock.Setup(x => x.GetProviderCourseTypesByUkprn(It.IsAny<int>()))
-            .ReturnsAsync(new List<ProviderCourseType> { new ProviderCourseType { CourseType = CourseType.ApprenticeshipUnit } });
+            .ReturnsAsync(new List<ProviderCourseType> { new ProviderCourseType { CourseType = CourseType.ShortCourse } });
 
         var ukprn = 10000001;
         var larsCode = "1";

--- a/src/SFA.DAS.Roatp.Application.UnitTests/Standards/Queries/GetAllStandards/GetAllStandardsQueryHandlerTests.cs
+++ b/src/SFA.DAS.Roatp.Application.UnitTests/Standards/Queries/GetAllStandards/GetAllStandardsQueryHandlerTests.cs
@@ -41,10 +41,10 @@ namespace SFA.DAS.Roatp.Application.UnitTests.Standards.Queries.GetAllStandards
             var expectedStandards = new List<Standard>
             {
                 new() { LarsCode = "1", Title = "standard 1", CourseType = CourseType.Apprenticeship },
-                new() { LarsCode = "2", Title = "short 1", CourseType = CourseType.ApprenticeshipUnit},
-                new() { LarsCode = "3", Title = "short 2", CourseType = CourseType.ApprenticeshipUnit}
+                new() { LarsCode = "2", Title = "short 1", CourseType = CourseType.ShortCourse},
+                new() { LarsCode = "3", Title = "short 2", CourseType = CourseType.ShortCourse}
             };
-            var courseTypeFilter = CourseType.ApprenticeshipUnit;
+            var courseTypeFilter = CourseType.ShortCourse;
 
             var repositoryMock = new Mock<IStandardsReadRepository>();
             repositoryMock.Setup(r => r.GetAllStandards()).ReturnsAsync(expectedStandards);
@@ -65,7 +65,7 @@ namespace SFA.DAS.Roatp.Application.UnitTests.Standards.Queries.GetAllStandards
                 new() { LarsCode = "1", Title = "standard 1", CourseType = CourseType.Apprenticeship },
                 new() { LarsCode = "2", Title = "standard 2", CourseType = CourseType.Apprenticeship }
             };
-            var courseTypeFilter = CourseType.ApprenticeshipUnit;
+            var courseTypeFilter = CourseType.ShortCourse;
             var repositoryMock = new Mock<IStandardsReadRepository>();
             repositoryMock.Setup(r => r.GetAllStandards()).ReturnsAsync(expectedStandards);
 

--- a/src/SFA.DAS.Roatp.Data/Configuration/ProviderCourseTypeConfiguration.cs
+++ b/src/SFA.DAS.Roatp.Data/Configuration/ProviderCourseTypeConfiguration.cs
@@ -20,11 +20,5 @@ public class ProviderCourseTypeConfiguration : IEntityTypeConfiguration<Provider
                 v => v.ToString(),
                 v => (CourseType)Enum.Parse(typeof(CourseType), v)
             );
-
-        builder.Property(p => p.LearningType).IsRequired().HasMaxLength(20)
-            .HasConversion(
-                v => v.ToString(),
-                v => (LearningType)Enum.Parse(typeof(LearningType), v)
-            );
     }
 }

--- a/src/SFA.DAS.Roatp.Database/PostDeploymentScripts/CSP-2360_Insert_Short_Course_test_data_for_course_management.sql
+++ b/src/SFA.DAS.Roatp.Database/PostDeploymentScripts/CSP-2360_Insert_Short_Course_test_data_for_course_management.sql
@@ -863,9 +863,9 @@ INSERT INTO #Standard VALUES ('ST1480_1.0','825','ST1480',2,'Insulation installa
 INSERT INTO #Standard VALUES ('ST1488_1.0','801','ST1488',2,'Food and beverage team member','1.0','',0,12,'Months','Catering and hospitality','Apprenticeship','Apprenticeship');
 INSERT INTO #Standard VALUES ('ST1498_1.1','824','ST1498',2,'Floorlayer wood based','1.1','',0,30,'Months','Construction and the built environment','Apprenticeship','Apprenticeship');
 INSERT INTO #Standard VALUES ('ST1502_1.0','823','ST1502',6,'Teacher - Undergraduate','1.0','Department for Education',1,45,'Months','Education and early years','Apprenticeship','Apprenticeship');
-INSERT INTO #Standard VALUES ('SC0001_1.0','ZSC00001','SC0001',3,'Digital Apprenticeship unit','1.0','',0,100,'Hours','Digital','ApprenticeshipUnit','ApprenticeshipUnit');
-INSERT INTO #Standard VALUES ('SC0002_1.0','ZSC00002','SC0002',4,'Teacher Assistant - Apprenticeship Unit','1.0','Department for Education',1,120,'Hours','Education and early years','ApprenticeshipUnit','ApprenticeshipUnit');
-INSERT INTO #Standard VALUES ('SC0004_1.0','ZSC00004','SC0004',4,'Nursing Apprenticeship unit','1.0','Nursing and Midwifery Council',1,120,'Hours','Health and science','ApprenticeshipUnit','ApprenticeshipUnit');
+INSERT INTO #Standard VALUES ('SC0001_1.0','ZSC00001','SC0001',3,'Digital Apprenticeship unit','1.0','',0,100,'Hours','Digital','ApprenticeshipUnit','ShortCourse');
+INSERT INTO #Standard VALUES ('SC0002_1.0','ZSC00002','SC0002',4,'Teacher Assistant - Apprenticeship Unit','1.0','Department for Education',1,120,'Hours','Education and early years','ApprenticeshipUnit','ShortCourse');
+INSERT INTO #Standard VALUES ('SC0004_1.0','ZSC00004','SC0004',4,'Nursing Apprenticeship unit','1.0','Nursing and Midwifery Council',1,120,'Hours','Health and science','ApprenticeshipUnit','ShortCourse');
 
 DELETE FROM [dbo].[Standard];
 INSERT INTO [dbo].[Standard]
@@ -1720,8 +1720,5 @@ update Standard set SectorSubjectAreaTier1 = 6 where Larscode = 'ZSC00001';
 update Standard set SectorSubjectAreaTier1 = 13 where Larscode = 'ZSC00002';
 update Standard set SectorSubjectAreaTier1 = 1 where Larscode = 'ZSC00004';
 update Standard set SectorSubjectAreaTier1 = 4 where Larscode = '1';
-
-
-
 
 -- END

--- a/src/SFA.DAS.Roatp.Database/Tables/ProviderCourseType.sql
+++ b/src/SFA.DAS.Roatp.Database/Tables/ProviderCourseType.sql
@@ -3,10 +3,9 @@
 	[Id] INT NOT NULL IDENTITY(1,1) PRIMARY KEY,
 	[Ukprn] INT NOT NULL,
 	[CourseType] nvarchar(50) NOT NULL,
-	[LearningType] nvarchar(20) NOT NULL
 );
 GO;
 
-CREATE NONCLUSTERED INDEX IX_ProviderCourseType_Ukprn_CourseType_LearningType
-ON [dbo].[ProviderCourseType] ([Ukprn],[CourseType],[LearningType])
+CREATE NONCLUSTERED INDEX IX_ProviderCourseType_Ukprn_CourseType
+ON [dbo].[ProviderCourseType] ([Ukprn],[CourseType])
 INCLUDE ([Id]);

--- a/src/SFA.DAS.Roatp.Domain/Entities/ProviderCourseType.cs
+++ b/src/SFA.DAS.Roatp.Domain/Entities/ProviderCourseType.cs
@@ -7,5 +7,4 @@ public class ProviderCourseType
     public int Id { get; set; }
     public int Ukprn { get; set; }
     public CourseType CourseType { get; set; }
-    public LearningType LearningType { get; set; }
 }

--- a/src/SFA.DAS.Roatp.Domain/Models/CourseTypes.cs
+++ b/src/SFA.DAS.Roatp.Domain/Models/CourseTypes.cs
@@ -3,5 +3,5 @@
 public enum CourseType
 {
     Apprenticeship,
-    ApprenticeshipUnit
+    ShortCourse
 }

--- a/src/SFA.DAS.Roatp.Domain/Models/LearningType.cs
+++ b/src/SFA.DAS.Roatp.Domain/Models/LearningType.cs
@@ -1,7 +1,0 @@
-﻿namespace SFA.DAS.Roatp.Domain.Models;
-
-public enum LearningType
-{
-    Standard,
-    ShortCourse
-}

--- a/src/SFA.DAS.Roatp.Jobs/ApiModels/AllowedCourseType.cs
+++ b/src/SFA.DAS.Roatp.Jobs/ApiModels/AllowedCourseType.cs
@@ -2,4 +2,4 @@
 
 namespace SFA.DAS.Roatp.Jobs.ApiModels;
 
-public record AllowedCourseType(int CourseTypeId, CourseType CourseType);
+public record AllowedCourseType(int CourseTypeId, CourseType CourseTypeName);

--- a/src/SFA.DAS.Roatp.Jobs/ApiModels/AllowedCourseType.cs
+++ b/src/SFA.DAS.Roatp.Jobs/ApiModels/AllowedCourseType.cs
@@ -2,4 +2,4 @@
 
 namespace SFA.DAS.Roatp.Jobs.ApiModels;
 
-public record AllowedCourseType(int CourseTypeId, CourseType CourseType, Domain.Models.LearningType LearningType);
+public record AllowedCourseType(int CourseTypeId, CourseType CourseType);

--- a/src/SFA.DAS.Roatp.Jobs/ApiModels/LearningType.cs
+++ b/src/SFA.DAS.Roatp.Jobs/ApiModels/LearningType.cs
@@ -1,6 +1,0 @@
-﻿namespace SFA.DAS.Roatp.Jobs.ApiModels;
-public enum LearningType
-{
-    Standard = 1,
-    ShortCourse = 2
-}

--- a/src/SFA.DAS.Roatp.Jobs/ApiModels/RegisteredProviderModel.cs
+++ b/src/SFA.DAS.Roatp.Jobs/ApiModels/RegisteredProviderModel.cs
@@ -2,6 +2,7 @@
 using SFA.DAS.Roatp.Domain.Models;
 
 namespace SFA.DAS.Roatp.Jobs.ApiModels;
+
 public class RegisteredProviderModel
 {
     public int Ukprn { get; set; }

--- a/src/SFA.DAS.Roatp.Jobs/Services/ReloadProviderRegistrationDetailService.cs
+++ b/src/SFA.DAS.Roatp.Jobs/Services/ReloadProviderRegistrationDetailService.cs
@@ -53,7 +53,7 @@ public class ReloadProviderRegistrationDetailService : IReloadProviderRegistrati
 
         foreach (var provider in providerRegistrationDetails)
         {
-            providerCourseTypes.AddRange(provider.AllowedCourseTypes.Select(providerCourseType => new ProviderCourseType { Ukprn = provider.Ukprn, CourseType = providerCourseType.CourseType }));
+            providerCourseTypes.AddRange(provider.AllowedCourseTypes.Select(providerCourseType => new ProviderCourseType { Ukprn = provider.Ukprn, CourseType = providerCourseType.CourseTypeName }));
         }
 
         _logger.LogInformation("Reloading {Count} provider course types", providerCourseTypes.Count);

--- a/src/SFA.DAS.Roatp.Jobs/Services/ReloadProviderRegistrationDetailService.cs
+++ b/src/SFA.DAS.Roatp.Jobs/Services/ReloadProviderRegistrationDetailService.cs
@@ -53,7 +53,7 @@ public class ReloadProviderRegistrationDetailService : IReloadProviderRegistrati
 
         foreach (var provider in providerRegistrationDetails)
         {
-            providerCourseTypes.AddRange(provider.AllowedCourseTypes.Select(providerCourseType => new ProviderCourseType { Ukprn = provider.Ukprn, CourseType = providerCourseType.CourseType, LearningType = providerCourseType.LearningType }));
+            providerCourseTypes.AddRange(provider.AllowedCourseTypes.Select(providerCourseType => new ProviderCourseType { Ukprn = provider.Ukprn, CourseType = providerCourseType.CourseType }));
         }
 
         _logger.LogInformation("Reloading {Count} provider course types", providerCourseTypes.Count);


### PR DESCRIPTION
This pull request primarily removes the concept of `LearningType` from the codebase and replaces the `ApprenticeshipUnit` value in the `CourseType` enum with `ShortCourse`. The changes affect domain models, database schema, test data, and related unit tests to ensure consistency throughout the application.
